### PR TITLE
Add .gitignore files for frontend and backend to enhance repository maintainability

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,26 @@
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+*.out
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool
+*.cover
+
+# Temporary files
+*.tmp
+*.swp
+*.log
+
+# Dependency directories (if using vendoring)
+vendor/
+
+# IDE-specific files
+.vscode/
+.idea/
+*.iml
+

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,30 @@
+# Node.js
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Build output
+dist/
+.next/
+out/
+build/
+coverage/
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+lerna-debug.log*
+
+# System files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
This PR adds `.gitignore` files for both the frontend (React) and backend (Golang) to prevent unnecessary or large files from being committed to the repository.

This pr closes #16 