### PR TITLE
Fix/remove hardcoded aws region

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -2,37 +2,38 @@ package config
 
 import (
 	"fmt"
-    "io/ioutil"
+	"io/ioutil"
 
-    "gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
+
 type Config struct {
-    Server struct {
-        Port int `yaml:"port"`
-    } `yaml:"server"`
+	Server struct {
+		Port int `yaml:"port"`
+	} `yaml:"server"`
 
-    Cognito struct {
-        AppClientId     string `yaml:"appClientId"`
-        AppClientSecret string `yaml:"appClientSecret"`
-        UserPoolId      string `yaml:"userPoolId"`
-        Region          string `yaml:"region"`
-    } `yaml:"cognito"`
+	Cognito struct {
+		AppClientId     string `yaml:"appClientId"`
+		AppClientSecret string `yaml:"appClientSecret"`
+		UserPoolId      string `yaml:"userPoolId"`
+		Region          string `yaml:"region"`
+	} `yaml:"cognito"`
 
-    Openai struct {
-        GptApiKey       string `yaml:"gptApiKey"`
-    } `yaml:"openai`
+	Openai struct {
+		GptApiKey string `yaml:"gptApiKey"`
+	} `yaml:"openai"`
 }
 
 func LoadConfig(path string) (*Config, error) {
-    data, err := ioutil.ReadFile(path)
-    if err != nil {
-        return nil, fmt.Errorf("failed to read config file: %w", err)
-    }
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
 
-    var cfg Config
-    if err := yaml.Unmarshal(data, &cfg); err != nil {
-        return nil, fmt.Errorf("failed to unmarshal yaml: %w", err)
-    }
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal yaml: %w", err)
+	}
 
-    return &cfg, nil
+	return &cfg, nil
 }

--- a/backend/controllers/auth.go
+++ b/backend/controllers/auth.go
@@ -63,17 +63,14 @@ func Login(ctx *gin.Context) {
 	if cfg == nil {
 		return
 	}
-	log.Println("I came inside the login function")
 
 	var request structs.LoginRequest
 	if err := ctx.ShouldBindJSON(&request); err != nil {
 		ctx.JSON(400, gin.H{"error": "Invalid input", "message": "Check email and password format"})
 		return
 	}
-	log.Println("I came inside the login function2")
 	token, err := loginWithCognito(cfg.Cognito.AppClientId, cfg.Cognito.AppClientSecret, request.Email, request.Password, ctx)
 	if err != nil {
-		log.Println("I came inside the login function3")
 		ctx.JSON(401, gin.H{"error": "Failed to sign in", "message": "Invalid email or password"})
 		return
 	}

--- a/backend/controllers/auth.go
+++ b/backend/controllers/auth.go
@@ -8,11 +8,12 @@ import (
 	"log"
 	"os"
 	"strings"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
-	"github.com/gin-gonic/gin"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
+	"github.com/gin-gonic/gin"
 )
 
 func SignUp(ctx *gin.Context) {
@@ -62,15 +63,17 @@ func Login(ctx *gin.Context) {
 	if cfg == nil {
 		return
 	}
+	log.Println("I came inside the login function")
 
 	var request structs.LoginRequest
 	if err := ctx.ShouldBindJSON(&request); err != nil {
 		ctx.JSON(400, gin.H{"error": "Invalid input", "message": "Check email and password format"})
 		return
 	}
-
+	log.Println("I came inside the login function2")
 	token, err := loginWithCognito(cfg.Cognito.AppClientId, cfg.Cognito.AppClientSecret, request.Email, request.Password, ctx)
 	if err != nil {
+		log.Println("I came inside the login function3")
 		ctx.JSON(401, gin.H{"error": "Failed to sign in", "message": "Invalid email or password"})
 		return
 	}
@@ -168,7 +171,12 @@ func loadConfig(ctx *gin.Context) *config.Config {
 }
 
 func signUpWithCognito(appClientId, appClientSecret, email, password string, ctx *gin.Context) error {
-	config, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion("ap-south-1"))
+	cfg := loadConfig(ctx)
+	if cfg == nil {
+		return fmt.Errorf("failed to load config")
+	}
+
+	config, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(cfg.Cognito.Region))
 	if err != nil {
 		log.Println("Error loading AWS config:", err)
 		return fmt.Errorf("failed to load AWS config: %v", err)
@@ -177,7 +185,6 @@ func signUpWithCognito(appClientId, appClientSecret, email, password string, ctx
 	cognitoClient := cognitoidentityprovider.NewFromConfig(config)
 
 	secretHash := utils.GenerateSecretHash(email, appClientId, appClientSecret)
-
 	signupInput := cognitoidentityprovider.SignUpInput{
 		ClientId:   aws.String(appClientId),
 		Password:   aws.String(password),
@@ -206,7 +213,12 @@ func signUpWithCognito(appClientId, appClientSecret, email, password string, ctx
 }
 
 func verifyEmailWithCognito(appClientId, appClientSecret, email, confirmationCode string, ctx *gin.Context) error {
-	config, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion("ap-south-1"))
+	cfg := loadConfig(ctx)
+	if cfg == nil {
+		return fmt.Errorf("failed to load config")
+	}
+
+	config, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(cfg.Cognito.Region))
 	if err != nil {
 		log.Println("Error loading AWS config:", err)
 		return fmt.Errorf("failed to load AWS config: %v", err)
@@ -234,7 +246,12 @@ func verifyEmailWithCognito(appClientId, appClientSecret, email, confirmationCod
 }
 
 func loginWithCognito(appClientId, appClientSecret, email, password string, ctx *gin.Context) (string, error) {
-	config, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion("ap-south-1"))
+	cfg := loadConfig(ctx)
+	if cfg == nil {
+		return "", fmt.Errorf("failed to load config")
+	}
+
+	config, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(cfg.Cognito.Region))
 	if err != nil {
 		return "", fmt.Errorf("failed to load AWS config")
 	}
@@ -261,7 +278,12 @@ func loginWithCognito(appClientId, appClientSecret, email, password string, ctx 
 }
 
 func initiateForgotPassword(appClientId, appClientSecret, email string, ctx *gin.Context) (*cognitoidentityprovider.ForgotPasswordOutput, error) {
-	config, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion("ap-south-1"))
+	cfg := loadConfig(ctx)
+	if cfg == nil {
+		return nil, fmt.Errorf("failed to load config")
+	}
+
+	config, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(cfg.Cognito.Region))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load AWS config")
 	}
@@ -284,7 +306,12 @@ func initiateForgotPassword(appClientId, appClientSecret, email string, ctx *gin
 }
 
 func confirmForgotPassword(appClientId, appClientSecret, email, code, newPassword string, ctx *gin.Context) (*cognitoidentityprovider.ConfirmForgotPasswordOutput, error) {
-	config, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion("ap-south-1"))
+	cfg := loadConfig(ctx)
+	if cfg == nil {
+		return nil, fmt.Errorf("failed to load config")
+	}
+
+	config, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(cfg.Cognito.Region))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load AWS config")
 	}
@@ -309,7 +336,12 @@ func confirmForgotPassword(appClientId, appClientSecret, email, code, newPasswor
 }
 
 func validateTokenWithCognito(userPoolId, token string, ctx *gin.Context) (bool, error) {
-	config, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion("ap-south-1"))
+	cfg := loadConfig(ctx)
+	if cfg == nil {
+		return false, fmt.Errorf("failed to load config")
+	}
+
+	config, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(cfg.Cognito.Region))
 	if err != nil {
 		return false, fmt.Errorf("failed to load AWS config")
 	}


### PR DESCRIPTION
### Summary
This pull request refactors the authentication controller to use the AWS region specified in the configuration file (`config.prod.yml`) instead of a hardcoded value. This change enhances the flexibility and configurability of the application, allowing it to adapt to different deployment environments without code changes.

### Changes
- Updated functions in `auth.go` to load AWS configuration using the region from the config file.
- Fixed a typo in the `config.go` file where the `openai` struct's YAML tag was missing a closing quote.

### Testing
- Verified that the application correctly loads the AWS region from the configuration file.
- Ensured that all authentication-related functionalities (sign-up, login, password reset, etc.) work as expected with the updated configuration.

### Additional Notes
- This change requires the `config.prod.yml` file to have the correct AWS region specified under the `cognito` section.