### PR TITLE
PR Labeling workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,19 @@
+docs:
+- changed-files:
+  - any-glob-to-any-file: '*.md'
+
+frontend:
+- changed-files:
+  - any-glob-to-any-file: 'frontend/**/*'
+  - any-glob-to-any-file: 'frontend/**/*.js'
+  - any-glob-to-any-file: 'frontend/**/*.ts'
+  - any-glob-to-any-file: 'frontend/**/*.tsx'
+  - any-glob-to-any-file: 'frontend/**/*.jsx'
+  - any-glob-to-any-file: 'frontend/**/*.css'
+  - any-glob-to-any-file: 'frontend/**/*.html'
+
+backend:
+  - changed-files:
+    - any-glob-to-any-file: 'backend/**/*'
+    - any-glob-to-any-file: 'backend/**/*.go'
+    - any-glob-to-any-file: 'backend/**/*.py'

--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -1,0 +1,40 @@
+name: PR Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  file-labeler:
+    needs: size-label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Add file-based labels
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          
+  size-label:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: size-label
+        uses: "pascalgn/size-label-action@v0.5.5"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          sizes: >
+            {
+              "0": "XS",
+              "20": "S",
+              "50": "M",
+              "200": "L",
+              "800": "XL",
+              "2000": "XXL"
+            }


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to automatically label pull requests for better maintainability:
- Size Labels: Applies XS (0-19 lines), S (20-49), M (50-199), L (200-799), XL (800-1999), or XXL (2000+ lines) based on lines changed.
- File-Based Labels: Applies docs, frontend, backend labels based on the files changed


1. **Why Automation?**  
   - Reduces manual tagging errors.  
   - Helps teams filter PRs.  
2. **How It Works**  
   - `size-label-action`: Uses PR diff stats to assign size labels.  
   - `labeler`: Scans file paths against regex rules in `labeler.yml`.  
--- 

### Setup for Maintainer :

1. Create Labels in Issues Tab:
   - size/XS,size/S, size/M, size/L, size/XL, size/XXL
   - docs, frontend, backend.
 
2. The workflows will automatically run whenever a pr is opened, changed, reopened

--- 
### POC 

![image](https://github.com/user-attachments/assets/c7148fce-f2b2-44eb-aa53-fcfa81dc0f8e)

---

