### PR TITLE
docs(config): fix config.example.yml structure for correct gemini/jwt/smtp setup

### DIFF
--- a/backend/config/config.example.yml
+++ b/backend/config/config.example.yml
@@ -1,0 +1,24 @@
+server:
+  port: 1313 # The port number your backend server will run on
+
+database:
+  uri: "mongodb+srv://<username>:<password>@<cluster-url>/<database-name>" # Replace with your MongoDB Atlas connection string  # Get this from your MongoDB Atlas dashboard after creating a cluster and database
+
+gemini:
+  apiKey: "<YOUR_GEMINI_API_KEY>" # API key for OpenAI / Gemini model access  # Obtain from your OpenRouter.ai or OpenAI account dashboard
+
+jwt:
+  secret: "<YOUR_JWT_SECRET>" # A secret string used to sign JWT tokens  # Generate a strong random string (e.g. use `openssl rand -hex 32`)
+  expiry: 1440 # Token expiry time in minutes (e.g. 1440 = 24 hours)
+
+smtp:
+  host: "smtp.gmail.com" # SMTP server host for sending emails (example is Gmail SMTP)
+  port: 587 # SMTP server port (587 for TLS)
+  username: "<YOUR_EMAIL_ADDRESS>" # Email username (your email address)
+  password: "<YOUR_EMAIL_PASSWORD_OR_APP_PASSWORD>" # Password for the email or app-specific password if 2FA is enabled
+  senderEmail: "<YOUR_EMAIL_ADDRESS>" # The 'from' email address used when sending mails
+  senderName: "DebateAI Team"
+
+googleOAuth:
+  clientID: "<YOUR_GOOGLE_OAUTH_CLIENT_ID>" # Google OAuth Client ID for OAuth login  # Obtain from Google Cloud Console (APIs & Services > Credentials > OAuth 2.0 Client IDs)
+


### PR DESCRIPTION
### Summary
This PR adds a corrected `backend/config/config.example.yml` file to serve as the canonical example for backend configuration.  
It aligns the structure with `config.Config` in `backend/config/config.go`.

---

### Changes
- Moved `gemini`, `jwt`, and `smtp` to the top level (siblings to `server`, `database`, and `googleOAuth`).
- Added placeholders for all secret values (no real credentials included).
- Updated example for clarity and onboarding consistency.

---

### Why
The previous example incorrectly nested `gemini`, `jwt`, and `smtp` under `database`, causing:
> `Failed to initialize Gemini client: You need an auth option to use this client.`

This update ensures that `cfg.Gemini.ApiKey` and related keys are correctly parsed, making backend setup straightforward for new contributors.

---

### How to Verify
1. Populate the secret placeholders in the new `config.example.yml`.
2. Run the backend.
3. The Gemini client should initialize successfully without auth-related errors.

---

### Notes
- Consider adding `backend/config/config.prod.yml` to `.gitignore` to prevent accidental commits of sensitive data.
- Related issue: [#109 ](https://github.com/AOSSIE-Org/DebateAI/issues/109)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added configuration example to help with application setup, providing template values and inline guidance for configuring server settings, database connection, external API integrations, authentication tokens, email service, and social login options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->