### PR TITLE
fix: auth pages theme and visibility improvements (Issue #142)

### DIFF
--- a/frontend/src/Pages/Authentication.tsx
+++ b/frontend/src/Pages/Authentication.tsx
@@ -2,28 +2,66 @@ import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { LoginForm, SignUpForm, OTPVerificationForm, ForgotPasswordForm, ResetPasswordForm } from './Authentication/forms.tsx';
 import { Link } from 'react-router-dom';
+import { ThemeToggle } from '@/components/ThemeToggle';
 
 const LeftSection = () => (
-  <div className="hidden md:flex w-full h-full flex-col justify-between bg-muted p-10 text-white">
-    <div className="flex items-center text-lg font-medium">
-      <Link to="/" className="flex items-center">
-        <svg>
-          {/* SVG Content */}
+  <div className="hidden md:flex w-full h-full flex-col justify-between bg-gradient-to-br from-orange-600 via-orange-500 to-yellow-500 dark:from-orange-700 dark:via-orange-600 dark:to-amber-600 p-10 text-white relative overflow-hidden">
+    {/* Background pattern */}
+    <div className="absolute inset-0 opacity-10">
+      <svg className="w-full h-full" viewBox="0 0 100 100" preserveAspectRatio="none">
+        <pattern id="grid" width="10" height="10" patternUnits="userSpaceOnUse">
+          <path d="M 10 0 L 0 0 0 10" fill="none" stroke="white" strokeWidth="0.5" />
+        </pattern>
+        <rect width="100" height="100" fill="url(#grid)" />
+      </svg>
+    </div>
+
+    {/* Logo */}
+    <div className="flex items-center text-lg font-bold z-10">
+      <Link to="/" className="flex items-center gap-2">
+        <svg viewBox="0 0 24 24" fill="currentColor" className="w-8 h-8">
+          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
         </svg>
-        Arguehub
+        Argue-Hub
       </Link>
     </div>
-    <div>
+
+    {/* Illustration - Debate Scene */}
+    <div className="flex-1 flex items-center justify-center z-10">
+      <svg viewBox="0 0 400 300" className="w-full max-w-md" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" role="img">
+        {/* Podiums */}
+        <rect x="40" y="200" width="80" height="80" rx="8" fill="white" fillOpacity="0.2" />
+        <rect x="280" y="200" width="80" height="80" rx="8" fill="white" fillOpacity="0.2" />
+
+        {/* Person 1 */}
+        <circle cx="80" cy="150" r="25" fill="white" fillOpacity="0.9" />
+        <rect x="60" y="175" width="40" height="30" rx="5" fill="white" fillOpacity="0.9" />
+
+        {/* Person 2 */}
+        <circle cx="320" cy="150" r="25" fill="white" fillOpacity="0.9" />
+        <rect x="300" y="175" width="40" height="30" rx="5" fill="white" fillOpacity="0.9" />
+
+        {/* Speech bubbles */}
+        <ellipse cx="140" cy="120" rx="40" ry="25" fill="white" fillOpacity="0.3" />
+        <ellipse cx="260" cy="100" rx="35" ry="22" fill="white" fillOpacity="0.3" />
+        <ellipse cx="200" cy="80" rx="30" ry="18" fill="white" fillOpacity="0.4" />
+
+        {/* Connecting lines */}
+        <path d="M100 160 Q200 100 300 160" stroke="white" strokeWidth="2" strokeDasharray="5,5" opacity="0.5" />
+      </svg>
+    </div>
+
+    {/* Quote */}
+    <div className="z-10">
       <blockquote className="space-y-2">
-        <p className="text-lg">
+        <p className="text-xl font-light italic">
           "We cannot solve our problems with the same thinking we used when we created them."
         </p>
-        <footer className="text-sm">Albert Einstein</footer>
+        <footer className="text-sm opacity-80">— Albert Einstein</footer>
       </blockquote>
     </div>
   </div>
 );
-
 
 
 interface RightSectionProps {
@@ -32,11 +70,11 @@ interface RightSectionProps {
   startOtpVerification: (email: string) => void;
   handleOtpVerified: () => void;
   startForgotPassword: () => void;
-  startResetPassword: (email: string) => void; 
-  handlePasswordReset: () => void; 
+  startResetPassword: (email: string) => void;
+  handlePasswordReset: () => void;
   emailForOTP: string;
-  emailForPasswordReset: string; 
-  infoMessage: string; 
+  emailForPasswordReset: string;
+  infoMessage: string;
 }
 
 const RightSection: React.FC<RightSectionProps> = ({
@@ -51,7 +89,13 @@ const RightSection: React.FC<RightSectionProps> = ({
   emailForPasswordReset,
   infoMessage,
 }) => (
-  <div className="flex items-center justify-center w-full h-full relative">
+  <div className="flex items-center justify-center w-full h-full relative bg-background text-foreground">
+    {/* Theme Toggle - top left */}
+    <div className="absolute left-4 top-4 md:left-8 md:top-8 w-40">
+      <ThemeToggle />
+    </div>
+
+    {/* Auth mode toggle - top right */}
     {authMode !== 'otpVerification' && authMode !== 'resetPassword' && (
       <Button
         className="absolute right-4 top-4 md:right-8 md:top-8"
@@ -61,16 +105,18 @@ const RightSection: React.FC<RightSectionProps> = ({
         {authMode === 'signup' ? 'Sign In' : 'Sign Up'}
       </Button>
     )}
-    <div className="flex flex-col items-center justify-center h-full w-3/5 text-center">
+
+    {/* Form container - increased width for mobile */}
+    <div className="flex flex-col items-center justify-center h-full w-[90%] sm:w-4/5 md:w-3/5 px-4 text-center">
       {authMode === 'login' && (
         <>
-          <h3 className="text-2xl font-medium my-4">Sign in to your account</h3>
+          <h3 className="text-2xl font-semibold my-4 text-foreground">Sign in to your account</h3>
           <LoginForm startForgotPassword={startForgotPassword} infoMessage={infoMessage} />
         </>
       )}
       {authMode === 'signup' && (
         <>
-          <h3 className="text-2xl font-medium my-4">Create an account</h3>
+          <h3 className="text-2xl font-semibold my-4 text-foreground">Create an account</h3>
           <SignUpForm startOtpVerification={startOtpVerification} />
         </>
       )}
@@ -98,7 +144,7 @@ const Authentication = () => {
   >('login');
 
   const [emailForOTP, setEmailForOTP] = useState('');
-  const [emailForPasswordReset, setEmailForPasswordReset] = useState(''); 
+  const [emailForPasswordReset, setEmailForPasswordReset] = useState('');
   const [infoMessage, setInfoMessage] = useState('');
 
   const toggleAuthMode = () => {
@@ -143,11 +189,11 @@ const Authentication = () => {
         startOtpVerification={startOtpVerification}
         handleOtpVerified={handleOtpVerified}
         startForgotPassword={startForgotPassword}
-        startResetPassword={startResetPassword} 
-        handlePasswordReset={handlePasswordReset} 
+        startResetPassword={startResetPassword}
+        handlePasswordReset={handlePasswordReset}
         emailForOTP={emailForOTP}
-        emailForPasswordReset={emailForPasswordReset} 
-        infoMessage={infoMessage} 
+        emailForPasswordReset={emailForPasswordReset}
+        infoMessage={infoMessage}
       />
     </div>
   );

--- a/frontend/src/Pages/Authentication/forms.tsx
+++ b/frontend/src/Pages/Authentication/forms.tsx
@@ -82,12 +82,12 @@ export const LoginForm: React.FC<LoginFormProps> = ({ startForgotPassword, infoM
             onChange={(e) => setPasswordVisible(e.target.checked)}
           />
         </div>
-        <div className='pl-2'>show password</div>
+        <div className='pl-2 text-sm text-foreground'>show password</div>
       </div>
       {error && <p className="text-sm text-red-500 mb-2">{error}</p>}
-      <p className="text-sm text-muted mb-4">
+      <p className="text-sm text-muted-foreground mb-4">
         Forgot your password?{' '}
-        <span className="underline cursor-pointer" onClick={startForgotPassword}>
+        <span className="underline cursor-pointer text-foreground hover:text-primary" onClick={startForgotPassword}>
           Reset Password
         </span>
       </p>
@@ -118,7 +118,7 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({ startOtpVerification }) 
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     if (password !== confirmPassword) {
       authContext.handleError('Passwords do not match');
       return;
@@ -190,7 +190,7 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({ startOtpVerification }) 
             onChange={(e) => setPasswordVisible(e.target.checked)}
           />
         </div>
-        <div className='pl-2'>show password</div>
+        <div className='pl-2 text-sm text-foreground'>show password</div>
       </div>
       {error && <p className="text-sm text-red-500 mb-2">{error}</p>}
       <Button type="submit" className="w-full mb-2" disabled={loading}>
@@ -224,8 +224,8 @@ export const OTPVerificationForm: React.FC<OTPVerificationFormProps> = ({ email,
 
   return (
     <div className="w-full flex flex-col items-center">
-      <h3 className="text-2xl font-medium my-4">Verify Your Email</h3>
-      <p className="mb-4">Enter the OTP sent to your email to complete the sign-up process.</p>
+      <h3 className="text-2xl font-medium my-4 text-foreground">Verify Your Email</h3>
+      <p className="mb-4 text-muted-foreground">Enter the OTP sent to your email to complete the sign-up process.</p>
       <form onSubmit={handleSubmit} className="w-full">
         <Input
           type="text"
@@ -279,8 +279,8 @@ export const ForgotPasswordForm: React.FC<ForgotPasswordFormProps> = ({
 
   return (
     <div className="w-full flex flex-col items-center">
-      <h3 className="text-2xl font-medium my-4">Reset Password</h3>
-      <p className="mb-4">Enter your email to receive a password reset code.</p>
+      <h3 className="text-2xl font-medium my-4 text-foreground">Reset Password</h3>
+      <p className="mb-4 text-muted-foreground">Enter your email to receive a password reset code.</p>
       <form onSubmit={handleSubmit} className="w-full">
         <Input
           type="email"
@@ -318,7 +318,7 @@ export const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ email, han
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     if (newPassword !== confirmNewPassword) {
       authContext.handleError('Passwords do not match');
       return;
@@ -331,7 +331,7 @@ export const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ email, han
 
   return (
     <div className="w-full flex flex-col items-center">
-      <h3 className="text-2xl font-medium my-4">Reset Your Password</h3>
+      <h3 className="text-2xl font-medium my-4 text-foreground">Reset Your Password</h3>
       <form onSubmit={handleSubmit} className="w-full">
         <Input
           type="text"
@@ -362,7 +362,7 @@ export const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ email, han
               onChange={(e) => setPasswordVisible(e.target.checked)}
             />
           </div>
-          <div className='pl-2'>show password</div>
+          <div className='pl-2 text-sm text-foreground'>show password</div>
         </div>
         {error && <p className="text-sm text-red-500 mb-2">{error}</p>}
         <Button type="submit" className="w-full" disabled={loading}>


### PR DESCRIPTION
Fixes #142

## Changes
- Added vibrant orange gradient with debate illustration to left panel
- Added ThemeToggle component to auth pages for easy theme switching
- Fixed text visibility in light/dark mode using `text-foreground` classes
- Increased form container width on mobile devices (`w-[90%]`)

## Files Modified
- [frontend/src/Pages/Authentication.tsx](cci:7://file:///c:/Users/td334/.gemini/antigravity/scratch/DebateAI/frontend/src/Pages/Authentication.tsx:0:0-0:0)
- [frontend/src/Pages/Authentication/forms.tsx](cci:7://file:///c:/Users/td334/.gemini/antigravity/scratch/DebateAI/frontend/src/Pages/Authentication/forms.tsx:0:0-0:0)

## Screenshots
(Optional: Add before/after screenshots if you want)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Theme toggle added to the authentication interface
  * Decorative illustration, updated logo text (Argue-Hub) and stylized quote added to the left panel
  * Improved mobile layout with wider form container for better usability

* **Style**
  * Updated typography, bolder headings and consistent foreground/muted color usage
  * Enhanced interactive element styles and hover states across auth forms

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->