### PR TITLE
Fix: authentication logic improved for saving only verified users.

### DIFF
--- a/backend/controllers/auth.go
+++ b/backend/controllers/auth.go
@@ -278,7 +278,7 @@ func Login(ctx *gin.Context) {
 	}
 
 	// Check if user is verified
-	if !user.IsVerified && user.Password == "" {
+	if !user.IsVerified {
 		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Email not verified"})
 		return
 	}

--- a/backend/structs/auth.go
+++ b/backend/structs/auth.go
@@ -6,7 +6,7 @@ type SignUpRequest struct {
 }
 
 type VerifyEmailRequest struct {
-	Token            string `json:"token" binding:"required"`
+	Email            string `json:"email" binding:"required,email"`
 	ConfirmationCode string `json:"confirmationCode" binding:"required"`
 }
 

--- a/backend/structs/auth.go
+++ b/backend/structs/auth.go
@@ -6,7 +6,7 @@ type SignUpRequest struct {
 }
 
 type VerifyEmailRequest struct {
-	Email            string `json:"email" binding:"required,email"`
+	Token            string `json:"token" binding:"required"`
 	ConfirmationCode string `json:"confirmationCode" binding:"required"`
 }
 

--- a/backend/utils/email.go
+++ b/backend/utils/email.go
@@ -41,7 +41,9 @@ func SendVerificationEmail(email, code string) error {
 			"MIME-Version: 1.0\r\n"+
 			"Content-Type: text/html; charset=\"UTF-8\"\r\n"+
 			"\r\n"+
-			"<p>Your verification code is: <strong>%s</strong></p>\r\n",
+			"<h2>Welcome to ArgueHub!</h2>\r\n"+
+			"<p>Your verification code is: <strong>%s</strong></p>\r\n"+
+			"<p><em>This code will expire in 24 hours.</em></p>\r\n",
 		email, cfg.SMTP.SenderName, cfg.SMTP.SenderEmail, code))
 
 	addr := fmt.Sprintf("%s:%d", cfg.SMTP.Host, cfg.SMTP.Port)

--- a/frontend/src/Pages/Authentication/forms.tsx
+++ b/frontend/src/Pages/Authentication/forms.tsx
@@ -218,7 +218,7 @@ export const OTPVerificationForm: React.FC<OTPVerificationFormProps> = ({ email,
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await verifyEmail(email, otp);
+    await verifyEmail(otp);
     handleOtpVerified();
   };
 

--- a/frontend/src/Pages/Authentication/forms.tsx
+++ b/frontend/src/Pages/Authentication/forms.tsx
@@ -118,7 +118,7 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({ startOtpVerification }) 
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     if (password !== confirmPassword) {
       authContext.handleError('Passwords do not match');
       return;
@@ -218,7 +218,7 @@ export const OTPVerificationForm: React.FC<OTPVerificationFormProps> = ({ email,
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await verifyEmail(otp);
+    await verifyEmail(email, otp);
     handleOtpVerified();
   };
 
@@ -318,7 +318,7 @@ export const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ email, han
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     if (newPassword !== confirmNewPassword) {
       authContext.handleError('Passwords do not match');
       return;

--- a/frontend/src/context/authContext.tsx
+++ b/frontend/src/context/authContext.tsx
@@ -22,7 +22,7 @@ interface AuthContextType {
   login: (email: string, password: string) => Promise<void>;
   logout: () => void;
   signup: (email: string, password: string) => Promise<void>;
-  verifyEmail: (email: string, code: string) => Promise<void>;
+  verifyEmail: (code: string) => Promise<void>;
   forgotPassword: (email: string) => Promise<void>;
   confirmForgotPassword: (
     email: string,
@@ -176,6 +176,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         const data = await response.json();
         throw new Error(data.message || 'Signup failed');
       }
+
+      // Store signup token for verification
+      const data = await response.json();
+      if (data.signupToken) {
+        localStorage.setItem('signupToken', data.signupToken);
+      }
     } catch (error) {
       handleError(error);
     } finally {
@@ -183,26 +189,62 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     }
   };
 
-  const verifyEmail = async (email: string, code: string) => {
+  const verifyEmail = async (code: string) => {
     setLoading(true);
     try {
+      // Get signup token from localStorage
+      const signupToken = localStorage.getItem('signupToken');
+      if (!signupToken) {
+        throw new Error('Signup token not found. Please sign up again.');
+      }
+
       const response = await fetch(`${baseURL}/verifyEmail`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, confirmationCode: code }),
+        body: JSON.stringify({ token: signupToken, confirmationCode: code }),
       });
 
       if (!response.ok) {
         const data = await response.json();
-        throw new Error(data.message || 'Verification failed');
+        throw new Error(data.error || 'Verification failed');
       }
-      // Optionally update userAtom with isVerified: true
-      setUser((prev: User | null) => {
-        if (!prev) return null;
-        const updatedUser = { ...prev, isVerified: true, verificationCode: undefined };
-        localStorage.setItem(USER_CACHE_KEY, JSON.stringify(updatedUser));
-        return updatedUser;
-      });
+
+      const data = await response.json();
+
+      // Clear signup token
+      localStorage.removeItem('signupToken');
+
+      // User is now verified and logged in
+      if (data.accessToken) {
+        setToken(data.accessToken);
+        localStorage.setItem('token', data.accessToken);
+
+        // Set user details
+        const normalizedUser: User = {
+          id: data.user?.id || data.user?._id || undefined,
+          email: data.user?.email || '',
+          displayName: data.user?.displayName || 'User',
+          bio: data.user?.bio || '',
+          rating: data.user?.rating || 1200,
+          rd: data.user?.rd || 350,
+          volatility: data.user?.volatility || 0.06,
+          lastRatingUpdate: data.user?.lastRatingUpdate || new Date().toISOString(),
+          avatarUrl: data.user?.avatarUrl || 'https://avatar.iran.liara.run/public/10',
+          twitter: data.user?.twitter || undefined,
+          instagram: data.user?.instagram || undefined,
+          linkedin: data.user?.linkedin || undefined,
+          password: '',
+          nickname: data.user?.nickname || 'User',
+          isVerified: true,
+          verificationCode: undefined,
+          resetPasswordCode: undefined,
+          createdAt: data.user?.createdAt || new Date().toISOString(),
+          updatedAt: data.user?.updatedAt || new Date().toISOString(),
+        };
+        setUser(normalizedUser);
+        localStorage.setItem(USER_CACHE_KEY, JSON.stringify(normalizedUser));
+        navigate('/');
+      }
     } catch (error) {
       handleError(error);
     } finally {


### PR DESCRIPTION
Closes #143 
Changes I made -

- Backend:
1. Fixed Login handler verification check to block all unverified users.
   Previously it relied on two checks - if password is empty and `isVerified = false` then only it blocks the user, but if only one was correct like `isVerified=false` it does not stops the user, i've added a single check to fix this.
2. SignUp handler now generates `jwt token` instead of inserting the user to databse.
3. Refactored VerifyEmail handler to decode `jwt token` and create verified user.
- Frontend:
1. Updated signup() to store `jwt token` in localStorage.
2. Updated verifyEmail() to retrieve the token from localStorage and send to backend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email verification required for new accounts with 24-hour expiry validation
  * Automatic login after successful email verification (access token + user returned)
  * Enhanced verification email content with welcome header and expiration notice
  * Sign-up now returns a generic success response (no user payload)

* **User Flow**
  * Login now only requires the account to be verified (relaxed setup checks)
  * Front-end stores access token and full user data on successful verification

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->