### PR TITLE
Fix: add eye icon toggle and remember me checkbox (Issue #60)

### DIFF
--- a/frontend/src/Pages/Authentication/forms.tsx
+++ b/frontend/src/Pages/Authentication/forms.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useContext, useState, useEffect } from 'react';
 import { AuthContext } from '../../context/authContext';
+import { Eye, EyeOff } from 'lucide-react';
 
 interface LoginFormProps {
   startForgotPassword: () => void;
@@ -13,6 +14,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({ startForgotPassword, infoM
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [passwordVisible, setPasswordVisible] = useState(false);
+  const [rememberMe, setRememberMe] = useState(false);
   const authContext = useContext(AuthContext);
 
   if (!authContext) {
@@ -23,6 +25,12 @@ export const LoginForm: React.FC<LoginFormProps> = ({ startForgotPassword, infoM
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    // Store remember me preference for session persistence
+    if (rememberMe) {
+      localStorage.setItem('rememberMe', 'true');
+    } else {
+      localStorage.removeItem('rememberMe');
+    }
     await login(email, password);
   };
 
@@ -67,30 +75,45 @@ export const LoginForm: React.FC<LoginFormProps> = ({ startForgotPassword, infoM
         onChange={(e) => setEmail(e.target.value)}
         className="mb-2"
       />
-      <Input
-        type={passwordVisible ? "text" : "password"}
-        placeholder="password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        className="mb-1"
-      />
-      <div className='w-full flex justify-start items-center pl-1'>
-        <div className='w-4'>
-          <Input
-            type='checkbox'
-            checked={passwordVisible}
-            onChange={(e) => setPasswordVisible(e.target.checked)}
-          />
-        </div>
-        <div className='pl-2'>show password</div>
+      {/* Password field with eye icon toggle */}
+      <div className="relative mb-2">
+        <Input
+          type={passwordVisible ? "text" : "password"}
+          placeholder="Enter your password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="pr-10"
+        />
+        <button
+          type="button"
+          onClick={() => setPasswordVisible(!passwordVisible)}
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+          aria-label={passwordVisible ? "Hide password" : "Show password"}
+        >
+          {passwordVisible ? <EyeOff size={18} /> : <Eye size={18} />}
+        </button>
       </div>
-      {error && <p className="text-sm text-red-500 mb-2">{error}</p>}
-      <p className="text-sm text-muted mb-4">
-        Forgot your password?{' '}
-        <span className="underline cursor-pointer" onClick={startForgotPassword}>
-          Reset Password
+
+      {/* Remember me and Forgot password row */}
+      <div className="flex justify-between items-center mb-4">
+        <label className="flex items-center gap-2 text-sm text-foreground cursor-pointer">
+          <input
+            type="checkbox"
+            checked={rememberMe}
+            onChange={(e) => setRememberMe(e.target.checked)}
+            className="w-4 h-4 rounded border-gray-300 text-primary focus:ring-primary"
+          />
+          Remember me
+        </label>
+        <span
+          className="text-sm text-primary hover:text-primary/80 underline cursor-pointer transition-colors"
+          onClick={startForgotPassword}
+        >
+          Forgot Password?
         </span>
-      </p>
+      </div>
+
+      {error && <p className="text-sm text-red-500 mb-2">{error}</p>}
       <Button type="submit" className="w-full mb-2" disabled={loading}>
         {loading ? 'Signing In...' : 'Sign In With Email'}
       </Button>
@@ -118,7 +141,7 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({ startOtpVerification }) 
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     if (password !== confirmPassword) {
       authContext.handleError('Passwords do not match');
       return;
@@ -168,29 +191,41 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({ startOtpVerification }) 
         onChange={(e) => setEmail(e.target.value)}
         className="mb-2"
       />
-      <Input
-        type={passwordVisible ? "text" : "password"}
-        placeholder="password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        className="mb-2"
-      />
-      <Input
-        type={passwordVisible ? "text" : "password"}
-        placeholder="confirm password"
-        value={confirmPassword}
-        onChange={(e) => setConfirmPassword(e.target.value)}
-        className="mb-4"
-      />
-      <div className='w-full flex justify-start items-center pl-1'>
-        <div className='w-4'>
-          <Input
-            type='checkbox'
-            checked={passwordVisible}
-            onChange={(e) => setPasswordVisible(e.target.checked)}
-          />
-        </div>
-        <div className='pl-2'>show password</div>
+      {/* Password field with eye icon toggle */}
+      <div className="relative mb-2">
+        <Input
+          type={passwordVisible ? "text" : "password"}
+          placeholder="Create a password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="pr-10"
+        />
+        <button
+          type="button"
+          onClick={() => setPasswordVisible(!passwordVisible)}
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+          aria-label={passwordVisible ? "Hide password" : "Show password"}
+        >
+          {passwordVisible ? <EyeOff size={18} /> : <Eye size={18} />}
+        </button>
+      </div>
+      {/* Confirm password field with eye icon toggle */}
+      <div className="relative mb-4">
+        <Input
+          type={passwordVisible ? "text" : "password"}
+          placeholder="Confirm your password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          className="pr-10"
+        />
+        <button
+          type="button"
+          onClick={() => setPasswordVisible(!passwordVisible)}
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+          aria-label={passwordVisible ? "Hide password" : "Show password"}
+        >
+          {passwordVisible ? <EyeOff size={18} /> : <Eye size={18} />}
+        </button>
       </div>
       {error && <p className="text-sm text-red-500 mb-2">{error}</p>}
       <Button type="submit" className="w-full mb-2" disabled={loading}>
@@ -318,7 +353,7 @@ export const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ email, han
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     if (newPassword !== confirmNewPassword) {
       authContext.handleError('Passwords do not match');
       return;
@@ -331,7 +366,7 @@ export const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ email, han
 
   return (
     <div className="w-full flex flex-col items-center">
-      <h3 className="text-2xl font-medium my-4">Reset Your Password</h3>
+      <h3 className="text-2xl font-medium my-4 text-foreground">Reset Your Password</h3>
       <form onSubmit={handleSubmit} className="w-full">
         <Input
           type="text"
@@ -340,29 +375,41 @@ export const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ email, han
           placeholder="Enter Code"
           className="w-full mb-2"
         />
-        <Input
-          type={passwordVisible ? "text" : "password"}
-          value={newPassword}
-          onChange={(e) => setNewPassword(e.target.value)}
-          placeholder="New Password"
-          className="w-full mb-2"
-        />
-        <Input
-          type={passwordVisible ? "text" : "password"}
-          value={confirmNewPassword}
-          onChange={(e) => setConfirmNewPassword(e.target.value)}
-          placeholder="Confirm New Password"
-          className="w-full mb-4"
-        />
-        <div className='w-full flex justify-start items-center pl-1'>
-          <div className='w-4'>
-            <Input
-              type='checkbox'
-              checked={passwordVisible}
-              onChange={(e) => setPasswordVisible(e.target.checked)}
-            />
-          </div>
-          <div className='pl-2'>show password</div>
+        {/* New password field with eye icon */}
+        <div className="relative mb-2">
+          <Input
+            type={passwordVisible ? "text" : "password"}
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            placeholder="New Password"
+            className="w-full pr-10"
+          />
+          <button
+            type="button"
+            onClick={() => setPasswordVisible(!passwordVisible)}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+            aria-label={passwordVisible ? "Hide password" : "Show password"}
+          >
+            {passwordVisible ? <EyeOff size={18} /> : <Eye size={18} />}
+          </button>
+        </div>
+        {/* Confirm new password field with eye icon */}
+        <div className="relative mb-4">
+          <Input
+            type={passwordVisible ? "text" : "password"}
+            value={confirmNewPassword}
+            onChange={(e) => setConfirmNewPassword(e.target.value)}
+            placeholder="Confirm New Password"
+            className="w-full pr-10"
+          />
+          <button
+            type="button"
+            onClick={() => setPasswordVisible(!passwordVisible)}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+            aria-label={passwordVisible ? "Hide password" : "Show password"}
+          >
+            {passwordVisible ? <EyeOff size={18} /> : <Eye size={18} />}
+          </button>
         </div>
         {error && <p className="text-sm text-red-500 mb-2">{error}</p>}
         <Button type="submit" className="w-full" disabled={loading}>


### PR DESCRIPTION
## Summary
UI improvements for Sign-in and Sign-up pages as requested in the issue.

## Changes
-  Replaced "show password" checkbox with eye icon toggle (👁️)
-  Added "Remember me" checkbox to login form
-  Fixed "Forgot Password?" link visibility and styling
-  Improved input placeholder text for better UX
-  Added accessibility labels for eye icon buttons

## Files Modified
- `frontend/src/Pages/Authentication/forms.tsx`

## Screenshots
Before: Checkbox with "show password" text
After: Clean eye icon toggle in password fields

## Testing
- Tested login form eye icon toggle
- Tested signup form eye icons for both password fields
- Tested reset password form eye icons


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Password visibility toggles added to login, signup, and password reset forms
  * "Remember me" option now available in the login form
  * Consolidated "Forgot Password" interaction into a single inline trigger

* **Improvements**
  * Refined password field styling and layout across authentication forms
  * Visual updates to reset-password headings and improved form accessibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->