### PR TITLE
Added concede (surrender) functionality for vs bot and vs player

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,1 +1,2 @@
 .env
+config.prod.yml

--- a/backend/routes/debatevsbot.go
+++ b/backend/routes/debatevsbot.go
@@ -13,5 +13,6 @@ func SetupDebateVsBotRoutes(router *gin.RouterGroup) {
 		vsbot.POST("/create", controllers.CreateDebate)
 		vsbot.POST("/debate", controllers.SendDebateMessage)
 		vsbot.POST("/judge", controllers.JudgeDebate)
+		vsbot.POST("/concede", controllers.ConcedeDebate)
 	}
 }

--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useRef } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
-import { sendDebateMessage, judgeDebate } from "@/services/vsbot";
+import { sendDebateMessage, judgeDebate, concedeDebate } from "@/services/vsbot";
 import JudgmentPopup from "@/components/JudgementPopup";
 import { Mic, MicOff } from "lucide-react";
 import { useAtom } from "jotai";
@@ -218,6 +218,7 @@ const extractJSON = (response: string): string => {
 
 const DebateRoom: React.FC = () => {
   const location = useLocation();
+  const navigate = useNavigate();
   const debateData = location.state as DebateProps;
   const phases = debateData.phaseTimings;
   const debateKey = `debate_${debateData.userId}_${debateData.topic}_${debateData.debateId}`;
@@ -257,6 +258,30 @@ const DebateRoom: React.FC = () => {
   const bot = allBots.find((b) => b.name === debateData.botName) || allBots[0];
   const userAvatar =
     user?.avatarUrl || "https://avatar.iran.liara.run/public/10";
+
+  const handleConcede = async () => {
+    if (window.confirm("Are you sure you want to concede? This will count as a loss.")) {
+      try {
+        if (debateData.debateId) {
+            await concedeDebate(debateData.debateId, state.messages);
+        }
+        
+        setState(prev => ({ ...prev, isDebateEnded: true }));
+        setPopup({
+            show: true,
+            message: "You have conceded the debate.",
+            isJudging: false
+        });
+        
+        setTimeout(() => {
+            navigate("/game");
+        }, 2000);
+
+      } catch (error) {
+        console.error("Error conceding:", error);
+      }
+    }
+  };
 
   // Initialize SpeechRecognition
   useEffect(() => {
@@ -800,6 +825,14 @@ const DebateRoom: React.FC = () => {
                 {user?.rating ? `Rating: ${user.rating}` : "Ready to argue!"}
               </div>
             </div>
+            {!state.isDebateEnded && (
+              <Button
+                onClick={handleConcede}
+                className="ml-auto bg-red-500 hover:bg-red-600 text-white rounded-md px-3 text-sm"
+              >
+                Concede
+              </Button>
+            )}
           </div>
           <div className="p-3 flex-1 overflow-y-auto">
             <p className="text-sm font-semibold text-orange-600 mb-1">

--- a/frontend/src/Pages/OnlineDebateRoom.tsx
+++ b/frontend/src/Pages/OnlineDebateRoom.tsx
@@ -797,6 +797,25 @@ const OnlineDebateRoom = (): JSX.Element => {
     startJudgmentPolling,
   ]);
 
+  const handleConcede = useCallback(() => {
+    if (window.confirm("Are you sure you want to concede? This will count as a loss.")) {
+      if (wsRef.current) {
+        wsRef.current.send(JSON.stringify({
+          type: "concede",
+          room: roomId,
+          userId: currentUserId,
+          username: currentUser?.displayName || "User"
+        }));
+      }
+      setDebatePhase(DebatePhase.Finished);
+      setPopup({
+        show: true,
+        message: "You have conceded the debate.",
+        isJudging: false,
+      });
+    }
+  }, [roomId, currentUserId, currentUser, setDebatePhase, setPopup]);
+
   const handlePhaseDone = useCallback(() => {
     const currentIndex = phaseOrder.indexOf(debatePhase);
     console.debug(
@@ -1240,6 +1259,14 @@ const OnlineDebateRoom = (): JSX.Element => {
               }
             }
           }
+          break;
+        case "concede":
+          setDebatePhase(DebatePhase.Finished);
+          setPopup({
+            show: true,
+            message: `${data.username || "Opponent"} has conceded the debate. You win!`,
+            isJudging: false,
+          });
           break;
         case "spectatorJoined":
           if (data.spectator?.connectionId) {
@@ -2090,6 +2117,16 @@ const OnlineDebateRoom = (): JSX.Element => {
               </span>
             )}
           </p>
+          {debatePhase !== DebatePhase.Finished && debatePhase !== DebatePhase.Setup && (
+            <div className="mt-2">
+              <Button
+                onClick={handleConcede}
+                className="bg-red-500 hover:bg-red-600 text-white rounded-md px-3 text-sm"
+              >
+                Concede
+              </Button>
+            </div>
+          )}
         </div>
       </div>
 

--- a/frontend/src/services/vsbot.ts
+++ b/frontend/src/services/vsbot.ts
@@ -100,6 +100,23 @@ export const sendDebateMessage = async (data: DebateRequest): Promise<{ response
   return { response: result.response }; // Adjusted to return bot's response directly
 };
 
+export const concedeDebate = async (debateId: string, history: DebateMessage[] = []): Promise<void> => {
+  const token = getAuthToken();
+  const response = await fetch(`${baseURL}/vsbot/concede`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token && { Authorization: `Bearer ${token}` }),
+    },
+    credentials: "include",
+    body: JSON.stringify({ debateId, history }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to concede debate");
+  }
+};
+
 // Function to judge a debate
 export const judgeDebate = async (data: JudgeRequest): Promise<JudgeResponse> => {
   const token = getAuthToken();


### PR DESCRIPTION
Fixes #154 

Also added config.prod.yml to .gitignore so that it devs could not push it accidentally

Video

https://github.com/user-attachments/assets/98a3c9e0-e165-4552-9a5b-172925751aaa



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added concede functionality allowing users to forfeit debates (both bot and multiplayer).
  * Concede button now appears in debate interface during active matches.
  * Confirmation prompt ensures accidental clicks are prevented.
  * Ratings and gamification automatically update upon concession.
  * Users are redirected after conceding.

* **Chores**
  * Updated backend configuration file exclusions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->