### PR TITLE
Fix: Input text invisible in DebateRoom dark theme

### DIFF
--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -838,7 +838,8 @@ const DebateRoom: React.FC = () => {
                       ? "Ask your question"
                       : "Provide your answer"
                   }
-                  className="flex-1 border-gray-300 focus:border-orange-400 rounded-md text-sm"
+                  className="flex-1 rounded-md text-sm border border-border bg-input text-foreground placeholder:text-muted-foreground focus:border-orange-400"
+
                 />
                 <Button
                   onClick={isRecognizing ? stopRecognition : startRecognition}


### PR DESCRIPTION
## Bug Fix
Fixes an issue where the debate input text was not visible in Dark Theme.

## Root Cause
Input field did not explicitly define text and background colors, causing
low contrast in dark mode.

## Solution
- Applied theme-aware Tailwind classes:
  - `text-foreground`
  - `bg-background`
  - `placeholder:text-muted-foreground`

## Affected Area
- DebateRoom input field

Closes #140 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated input field styling to enhance visual appearance and improve interface consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->