### PR TITLE
Fix: Sign Up link redirects to login page

### DIFF
--- a/frontend/src/Pages/Authentication.tsx
+++ b/frontend/src/Pages/Authentication.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { LoginForm, SignUpForm, OTPVerificationForm, ForgotPasswordForm, ResetPasswordForm } from './Authentication/forms.tsx';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import DebateCover from '../assets/DebateCover4.svg';
 import { ThemeToggle } from '@/components/ThemeToggle';
 
@@ -102,10 +102,11 @@ const RightSection: React.FC<RightSectionProps> = ({
 
 
 const Authentication = () => {
+  const location = useLocation();
   // Extend authMode to include 'resetPassword'
   const [authMode, setAuthMode] = useState<
     'login' | 'signup' | 'otpVerification' | 'forgotPassword' | 'resetPassword'
-  >('login');
+  >(location.state?.isSignUp ? 'signup' : 'login');
 
   const [emailForOTP, setEmailForOTP] = useState('');
   const [emailForPasswordReset, setEmailForPasswordReset] = useState('');


### PR DESCRIPTION
Fixes #221 

## Description
This PR fixes a navigation bug where clicking the "Sign Up" button redirects users to the login page instead of displaying the signup form. Users had to click "Sign Up" again to see the signup form.

The issue was caused by the `authMode` state not respecting the `useLocation()` state passed during navigation.

## Changes Made
- Modified `Authentication.tsx` to initialize `authMode` with `location.state?.isSignUp` 
- This ensures the signup form displays immediately when navigated from the Sign Up button
- No longer defaults to login mode on every auth page load

## Video Proof

https://github.com/user-attachments/assets/70a5be5d-84f8-4089-91b5-fd6a3110044b


## How to Test
1. Pull this branch locally
2. Start the frontend: `npm run dev`
3. Click the "Sign Up" button on the home page
4. Verify the signup form displays immediately
5. Try switching between Sign In and Sign Up using the top-right button
6. Verify both forms load correctly without page redirects

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have tested this on desktop and mobile viewports
- [x] The fix resolves the reported issue
- [x] No breaking changes introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The authentication page now intelligently routes users to either the signup or login view based on their navigation context, providing a more seamless onboarding experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->