### PR TITLE
Fix matchmaking UI stuck in searching state after page refresh

### DIFF
--- a/frontend/src/components/Matchmaking.tsx
+++ b/frontend/src/components/Matchmaking.tsx
@@ -24,6 +24,8 @@ interface MatchmakingMessage {
   error?: string;
 }
 
+
+
 const Matchmaking: React.FC = () => {
   const [pool, setPool] = useState<MatchmakingPool[]>([]);
   const [isConnected, setIsConnected] = useState(false);
@@ -32,6 +34,13 @@ const Matchmaking: React.FC = () => {
   const { user, isLoading } = useUser();
   const wsRef = useRef<WebSocket | null>(null);
   const navigate = useNavigate();
+
+    // Reset matchmaking UI state on page refresh
+    useEffect(() => {
+      setIsInPool(false);
+      setWaitTime(0);
+    }, []);
+
 
   useEffect(() => {
     // If still loading, wait


### PR DESCRIPTION
Summary
Fixes a frontend issue where the matchmaking UI remains stuck in the
"Searching..." state after a page refresh.

Problem
If a user refreshes the matchmaking page while searching for a debate partner,
the UI incorrectly continues to show the searching state and prevents the user
from starting matchmaking again.

 Solution
 Reset matchmaking state (`isInPool`, `waitTime`) on component mount
 Ensure UI state is consistent after page refresh
 Allow users to safely rejoin matchmaking

Changes
Frontend-only fix in the Matchmaking page
No backend changes included

 Testing
Joined matchmaking
Refreshed the page
Verified searching state resets correctly
Confirmed user can start matchmaking again

Impact
Improves user experience
Prevents users from being stuck indefinitely
Safe, minimal change

close #224 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed matchmaking interface state to properly reset on page load, ensuring a clean UI experience after browser refresh.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->