### PR TITLE
Fix: Matchmaking UI stuck in searching state 

### DIFF
--- a/frontend/src/components/Matchmaking.tsx
+++ b/frontend/src/components/Matchmaking.tsx
@@ -23,7 +23,6 @@ interface MatchmakingMessage {
   pool?: MatchmakingPool[] | string;
   error?: string;
 }
-
 const Matchmaking: React.FC = () => {
   const [pool, setPool] = useState<MatchmakingPool[]>([]);
   const [isConnected, setIsConnected] = useState(false);
@@ -33,17 +32,22 @@ const Matchmaking: React.FC = () => {
   const wsRef = useRef<WebSocket | null>(null);
   const navigate = useNavigate();
 
+    // Reset matchmaking UI state on page refresh
+    useEffect(() => {
+      setIsInPool(false);
+      setWaitTime(0);
+    }, []);
+
+
   useEffect(() => {
     // If still loading, wait
     if (isLoading) {
       return;
     }
-
     if (!user) {
       navigate('/login');
       return;
     }
-
     // Get token from localStorage
     const token = localStorage.getItem('token');
     if (!token) {


### PR DESCRIPTION

#### closes #224 

### PR description
If a user refreshes the matchmaking page while searching for a debate partner, the UI incorrectly continues to show the searching state and prevents the user from starting matchmaking again. solution for this is, Reset matchmaking state (isInPool, waitTime) on component mount, Ensure UI state is consistent after page refresh and Allow users to safely rejoin matchmaking

This PR Fixes a frontend issue where the matchmaking UI remains stuck in the "Searching..." state after a page refresh.

---

### Changes made

Frontend-only fix in the Matchmaking page
No backend changes included

---

### Testing
- Joined matchmaking
- Refreshed the page
- Verified searching state resets correctly
- Confirmed user can start matchmaking again

---

### Impact

- Improves user experience
- Prevents users from being stuck indefinitely
- Safe, minimal change



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed matchmaking interface state not resetting properly on page refresh. Queue status and wait timer are now cleared when the page reloads, providing a clean starting state and preventing stale data display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->