### PR TITLE
feat: add lightweight /health endpoint

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -83,6 +83,9 @@ func main() {
 	}
 }
 
+// setupRouter initializes the HTTP routes for the backend server.
+// It includes a lightweight /health endpoint used to verify server availability
+// without depending on external services such as databases or caches.
 func setupRouter(cfg *config.Config) *gin.Engine {
 	router := gin.Default()
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -21,16 +21,19 @@ import (
 func main() {
 	// Load the configuration from the specified YAML file
 	cfg, err := config.LoadConfig("./config/config.prod.yml")
+
 	if err != nil {
 		panic("Failed to load config: " + err.Error())
 	}
+	log.Println("DEBUG Mongo URI =", cfg.Database.URI)
 
+	
 	services.InitDebateVsBotService(cfg)
 	services.InitCoachService()
 	services.InitRatingService(cfg)
 
 	// Connect to MongoDB using the URI from the configuration
-	if err := db.ConnectMongoDB(cfg.Database.URI); err != nil {
+	if err := db.ConnectMongoDB("mongodb://localhost:27017/debateai"); err != nil {
 		panic("Failed to connect to MongoDB: " + err.Error())
 	}
 	log.Println("Connected to MongoDB")
@@ -80,6 +83,14 @@ func main() {
 
 func setupRouter(cfg *config.Config) *gin.Engine {
 	router := gin.Default()
+
+	// Health check endpoint
+	router.GET("/health", func(c *gin.Context) {
+		c.JSON(200, gin.H{
+			"status":  "ok",
+			"version": "1.0.0",
+		})
+	})
 
 	// Set trusted proxies (adjust as needed)
 	router.SetTrustedProxies([]string{"127.0.0.1", "localhost"})

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -33,9 +33,11 @@ func main() {
 
 	// Connect to MongoDB using the configured URI
 	// MongoDB is optional so the server (and /health) can start without it
+	mongoReady := true
 	if err := db.ConnectMongoDB(cfg.Database.URI); err != nil {
 		log.Printf("⚠️ Warning: Failed to connect to MongoDB: %v", err)
 		log.Println("⚠️ Continuing without MongoDB")
+		mongoReady = false
 	} else {
 		log.Println("Connected to MongoDB")
 	}
@@ -67,9 +69,13 @@ func main() {
 
 	utils.SetJWTSecret(cfg.JWT.Secret)
 
-	// Seed initial debate-related data
-	utils.SeedDebateData()
-	utils.PopulateTestUsers()
+	// Seed initial debate-related data only if MongoDB is available
+	if mongoReady {
+		utils.SeedDebateData()
+		utils.PopulateTestUsers()
+	} else {
+		log.Println("Skipping SeedDebateData and PopulateTestUsers because MongoDB is unavailable")
+	}
 
 	// Create uploads directory
 	os.MkdirAll("uploads", os.ModePerm)


### PR DESCRIPTION
### Summary
Adds a lightweight `/health` endpoint to verify backend availability during local development and CI.

### Details
- Returns HTTP 200 with a simple JSON response
- No authentication required
- No dependency on DB, Redis, or external services
- Reachable even if optional services fail

### Motivation
This improves local debugging and onboarding by providing a clear backend availability signal.

Closes #249 

(Any issue please communicate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a health endpoint (GET /health) reporting service status.

* **Bug Fixes / Reliability**
  * Server stays up if the database is unreachable; connection failures now log a warning instead of stopping the service.
  * Data seeding for debates and test users only occurs when the database is available.

* **Refactor**
  * Centralized router initialization for clearer route setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->