### PR TITLE
fix: track and persist elo rating changes history

### DIFF
--- a/backend/controllers/debatevsbot_controller.go
+++ b/backend/controllers/debatevsbot_controller.go
@@ -274,6 +274,7 @@ func JudgeDebate(c *gin.Context) {
 		latestDebate.Topic,
 		latestDebate.BotName,
 		resultStatus,
+		0.0,
 		req.History,
 		nil,
 	)
@@ -590,6 +591,7 @@ func ConcedeDebate(c *gin.Context) {
 		debate.Topic,
 		debate.BotName,
 		"loss",
+		0.0,
 		historyToSave,
 		nil,
 	)

--- a/backend/controllers/profile_controller.go
+++ b/backend/controllers/profile_controller.go
@@ -254,7 +254,7 @@ func GetProfile(c *gin.Context) {
 				"opponent":   transcript.Opponent,
 				"debateType": transcript.DebateType,
 				"date":       transcript.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
-				"eloChange":  0, // TODO: Add actual Elo change tracking
+				"eloChange":  transcript.EloChange,
 			})
 		}
 

--- a/backend/controllers/transcript_controller.go
+++ b/backend/controllers/transcript_controller.go
@@ -113,6 +113,7 @@ func SaveDebateTranscriptHandler(c *gin.Context) {
 		req.Topic,
 		req.Opponent,
 		req.Result,
+		0.0,
 		req.Messages,
 		req.Transcripts,
 	)
@@ -295,6 +296,7 @@ func CreateTestTranscriptHandler(c *gin.Context) {
 		"Climate Change Action",
 		"AI Bot",
 		"win",
+		0.0,
 		testMessages,
 		nil,
 	)
@@ -353,6 +355,7 @@ func CreateTestBotDebateHandler(c *gin.Context) {
 		"AI Benefits vs Risks",
 		"Expert Emma",
 		"win",
+		0.0,
 		testMessages,
 		nil,
 	)

--- a/backend/models/transcript.go
+++ b/backend/models/transcript.go
@@ -30,6 +30,7 @@ type SavedDebateTranscript struct {
 	Topic       string             `bson:"topic" json:"topic"`
 	Opponent    string             `bson:"opponent" json:"opponent"` // Bot name or opponent email
 	Result      string             `bson:"result" json:"result"`     // "win", "loss", "draw", "pending"
+	EloChange   float64            `bson:"eloChange" json:"eloChange"`
 	Messages    []Message          `bson:"messages" json:"messages"`
 	Transcripts map[string]string  `bson:"transcripts,omitempty" json:"transcripts,omitempty"` // For user vs user debates
 	CreatedAt   time.Time          `bson:"createdAt" json:"createdAt"`


### PR DESCRIPTION
## Description 
This PR implements the missing functionality for storing and retrieving Elo rating changes for each debate match. Previously, the "Recent Debates" section in user profiles displayed a "0" change for all matches because the rating delta was not being persisted.

## Changes
- **Data Model**: Added `EloChange` (float64) field to the `SavedDebateTranscript` struct in `backend/models/transcript.go`.
- **Service Logic**: Refactored `transcriptservice.go` to calculate ratings *before* saving the transcript. This ensures the rating delta is captured and saved with the debate record.
- **Controllers**: Updated `profile_controller.go` to return the actual stored Elo change instead of a hardcoded placeholder. Updated `debatevsbot_controller.go` and `transcript_controller.go` to support the new function signature.

## Fixes
- Fixes the issue where users could not see the impact of individual matches on their rating.
- Replaces the `TODO: Add actual Elo change tracking` placeholder in the profile controller.

## Testing
- Verified that the `EloChange` field is correctly marshaled and stored using a model verification script.
- Verified that the backend compiles successfully with the new changes.


closes #265 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Debate transcripts now track and display Elo rating changes for participants.
  * User profiles now show actual rating changes from recent debates instead of placeholder values.
  * Both participants' rating changes are properly recorded and persisted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->