### PR TITLE
Debate module does not respect global dark/light theme

### DIFF
--- a/backend/controllers/profile_controller.go
+++ b/backend/controllers/profile_controller.go
@@ -254,7 +254,7 @@ func GetProfile(c *gin.Context) {
 				"opponent":   transcript.Opponent,
 				"debateType": transcript.DebateType,
 				"date":       transcript.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
-				"eloChange":  0, // TODO: Add actual Elo change tracking
+				"eloChange": transcript.EloChange,// TODO: Add actual Elo change tracking
 			})
 		}
 

--- a/backend/models/transcript.go
+++ b/backend/models/transcript.go
@@ -30,11 +30,13 @@ type SavedDebateTranscript struct {
 	Topic       string             `bson:"topic" json:"topic"`
 	Opponent    string             `bson:"opponent" json:"opponent"` // Bot name or opponent email
 	Result      string             `bson:"result" json:"result"`     // "win", "loss", "draw", "pending"
+	EloChange   float64            `bson:"eloChange" json:"eloChange"`
 	Messages    []Message          `bson:"messages" json:"messages"`
-	Transcripts map[string]string  `bson:"transcripts,omitempty" json:"transcripts,omitempty"` // For user vs user debates
+	Transcripts map[string]string  `bson:"transcripts,omitempty" json:"transcripts,omitempty"`
 	CreatedAt   time.Time          `bson:"createdAt" json:"createdAt"`
 	UpdatedAt   time.Time          `bson:"updatedAt" json:"updatedAt"`
 }
+
 
 func (s SavedDebateTranscript) MarshalJSON() ([]byte, error) {
 	type Alias SavedDebateTranscript

--- a/backend/services/transcriptservice.go
+++ b/backend/services/transcriptservice.go
@@ -186,6 +186,7 @@ func SubmitTranscripts(
 					resultFor,
 					[]models.Message{}, // You might want to reconstruct messages from transcripts
 					forSubmission.Transcripts,
+					forRecord.RatingChange
 				)
 				if err != nil {
 				}
@@ -659,7 +660,7 @@ func buildFallbackJudgeResult(merged map[string]string) string {
 }
 
 // SaveDebateTranscript saves a debate transcript for later viewing
-func SaveDebateTranscript(userID primitive.ObjectID, email, debateType, topic, opponent, result string, messages []models.Message, transcripts map[string]string) error {
+func SaveDebateTranscript(userID primitive.ObjectID, email, debateType, topic, opponent, result string, messages []models.Message, transcripts map[string]string, eloChange float64) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -682,11 +683,13 @@ func SaveDebateTranscript(userID primitive.ObjectID, email, debateType, topic, o
 
 		// If the result has changed or is "pending", update the transcript
 		if existingTranscript.Result != result || existingTranscript.Result == "pending" {
+
 			update := bson.M{
 				"$set": bson.M{
 					"result":      result,
 					"messages":    messages,
 					"transcripts": transcripts,
+					"eloChange":   eloChange,
 					"updatedAt":   time.Now(),
 				},
 			}
@@ -712,6 +715,7 @@ func SaveDebateTranscript(userID primitive.ObjectID, email, debateType, topic, o
 		Opponent:    opponent,
 		Result:      result,
 		Messages:    messages,
+		EloChange:   eloChange, 
 		Transcripts: transcripts,
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,57 +50,59 @@ function AppRoutes() {
   }
   const { isAuthenticated } = authContext;
   return (
-    <Routes>
-      {/* Public routes */}
-      <Route
-        path='/'
-        element={
-          isAuthenticated ? <Navigate to='/startDebate' replace /> : <Home />
-        }
-      />
-      <Route path='/auth' element={<Authentication />} />
-      <Route path='/admin/login' element={<AdminSignup />} />
-      <Route path='/admin/dashboard' element={<AdminDashboard />} />
-      {/* Protected routes with layout */}
-      <Route element={<ProtectedRoute />}>
-        <Route path='/' element={<Layout />}>
-          <Route path='startDebate' element={<StartDebate />} />
-          <Route path='leaderboard' element={<Leaderboard />} />
-          <Route path='profile' element={<Profile />} />
-          <Route path='community' element={<CommunityFeed />} />
-          <Route path='about' element={<About />} />
-          <Route path='team-builder' element={<TeamBuilder />} />
-          <Route path='game/:userId' element={<DebateApp />} />
-          <Route path='bot-selection' element={<BotSelection />} />
-          <Route path='/tournaments' element={<TournamentHub />} />
-          <Route path='/coach' element={<CoachPage />} />
-          <Route
-            path='/tournament/:id/bracket'
-            element={<TournamentDetails />}
-          />
-          <Route
-            path='coach/strengthen-argument'
-            element={<StrengthenArgument />}
-          />
-          <Route path='/coach' element={<CoachPage />} />
-          <Route
-            path='coach/strengthen-argument'
-            element={<StrengthenArgument />}
-          />{' '}
-          {/* Add this route */}
-          <Route path='coach/pros-cons' element={<ProsConsChallenge />} />
+      <Routes>
+        {/* Public routes */}
+        <Route
+          path="/"
+          element={
+            isAuthenticated ? <Navigate to="/startDebate" replace /> : <Home />
+          }
+        />
+        <Route path="/auth" element={<Authentication />} />
+        <Route path="/admin/login" element={<AdminSignup />} />
+        <Route path="/admin/dashboard" element={<AdminDashboard />} />
+
+        {/* Protected routes */}
+        <Route element={<ProtectedRoute />}>
+          <Route element={<Layout />}>
+            <Route path="startDebate" element={<StartDebate />} />
+            <Route path="leaderboard" element={<Leaderboard />} />
+            <Route path="profile" element={<Profile />} />
+            <Route path="community" element={<CommunityFeed />} />
+            <Route path="about" element={<About />} />
+            <Route path="team-builder" element={<TeamBuilder />} />
+            <Route path="game/:userId" element={<DebateApp />} />
+            <Route path="bot-selection" element={<BotSelection />} />
+            <Route path="tournaments" element={<TournamentHub />} />
+            <Route
+              path="tournament/:id/bracket"
+              element={<TournamentDetails />}
+            />
+
+            {/* Coach routes */}
+            <Route path="coach" element={<CoachPage />}>
+              <Route
+                path="strengthen-argument"
+                element={<StrengthenArgument />}
+              />
+              <Route path="pros-cons" element={<ProsConsChallenge />} />
+            </Route>
+          </Route>
+
+          {/* Debate routes (outside layout) */}
+          <Route path="debate/:roomId" element={<DebateRoom />} />
+          <Route path="debate-room/:roomId" element={<OnlineDebateRoom />} />
+          <Route path="team-debate/:debateId" element={<TeamDebateRoom />} />
+          <Route path="spectator/:roomId" element={<ChatRoom />} />
+          <Route path="debate/:debateID/view" element={<ViewDebate />} />
+          <Route path="view-debate/:debateID" element={<ViewDebate />} />
+          <Route path="speech-test" element={<SpeechTest />} />
         </Route>
-        <Route path='/debate/:roomId' element={<DebateRoom />} />
-        <Route path='/debate-room/:roomId' element={<OnlineDebateRoom />} />
-        <Route path='/team-debate/:debateId' element={<TeamDebateRoom />} />
-        <Route path='/spectator/:roomId' element={<ChatRoom />} />
-        <Route path='/debate/:debateID/view' element={<ViewDebate />} />
-        <Route path='/view-debate/:debateID' element={<ViewDebate />} />
-        <Route path='/speech-test' element={<SpeechTest />} />
-      </Route>
-      {/* Redirect unknown routes */}
-      <Route path='*' element={<Navigate to='/' replace />} />
-    </Routes>
+
+        {/* Redirect unknown routes */}
+        <Route path="*" element={<Navigate to="/" replace />} />
+  </Routes>
+
   );
 }
 

--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -220,7 +220,6 @@ const DebateRoom: React.FC = () => {
   const judgingRef = useRef(false);
   const navigate = useNavigate();
   const location = useLocation();
-  const navigate = useNavigate();
   const debateData = location.state as DebateProps;
   const phases = debateData.phaseTimings;
   const debateKey = `debate_${debateData.userId}_${debateData.topic}_${debateData.debateId}`;

--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -702,9 +702,12 @@ const DebateRoom: React.FC = () => {
   const currentTurnType = turnTypes[state.currentPhase][state.phaseStep];
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-200 p-4">
+    <div className="min-h-screen p-4 bg-gradient-to-br from-gray-50 to-gray-200
+  dark:from-zinc-900 dark:to-zinc-800">
       <div className="w-full max-w-5xl mx-auto py-2">
-        <div className="bg-gradient-to-r from-orange-100 via-white to-orange-100 rounded-xl p-4 text-center transition-all duration-300 hover:shadow-lg">
+       <div className="rounded-xl p-4 text-center transition-all duration-300 hover:shadow-lg bg-gradient-to-r from-orange-100 via-white to-orange-100
+    dark:from-zinc-800 dark:via-zinc-900 dark:to-zinc-800
+       ">
           <h1 className="text-3xl font-bold text-gray-900 tracking-tight">
             Debate: {debateData.topic}
           </h1>
@@ -728,7 +731,7 @@ const DebateRoom: React.FC = () => {
 
       {popup.show && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
-          <div className="bg-white rounded-xl shadow-2xl p-6 max-w-md w-full transform transition-all duration-300 scale-105 border border-orange-200">
+         <div className="bg-white dark:bg-zinc-900 rounded-xl p-6 max-w-m w-full transform transition-all duration-300 scale-105 shadow-2xl border border-orange-200 dark:border-orange-400/30">
             {popup.isJudging ? (
               <div className="flex flex-col items-center">
                 <div className="animate-spin rounded-full h-16 w-16 border-t-4 border-blue500 mb-4"></div>
@@ -768,11 +771,7 @@ const DebateRoom: React.FC = () => {
 
       <div className="w-full max-w-5xl mx-auto flex flex-col md:flex-row gap-3">
         {/* Bot Section */}
-        <div
-          className={`relative w-full md:w-1/2 ${
-            state.isBotTurn ? "animate-glow" : ""
-          } bg-white border border-gray-200 shadow-md h-[540px] flex flex-col`}
-        >
+        <div className={`relative w-full md:w-1/2 ${state.isBotTurn ? "animate-glow" : ""} h-[540px] flex flex-col shadow-md bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-700`}>
           <div className="p-2 bg-gray-50 flex items-center gap-2">
             <div className="w-12 h-12 flex-shrink-0">
               <img
@@ -922,7 +921,7 @@ const DebateRoom: React.FC = () => {
             box-shadow: 0 0 5px rgba(255, 149, 0, 0.5);
           }
           50% {
-            box-shadow: 0 0 20px rgba(255, 149, 0, 0.8);
+            box-shadow: 0 0 20px rgba(255, 180, 80, 0.9);
           }
           100% {
             box-shadow: 0 0 5px rgba(255, 149, 0, 0.5);

--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -10,9 +10,6 @@ import { userAtom } from "@/state/userAtom";
 import { useNavigate } from "react-router-dom";
 
 
-const judgingRef = useRef(false);
-const navigate = useNavigate();
-
 // Bot type definition (same as in BotSelection)
 interface Bot {
   name: string;
@@ -222,6 +219,8 @@ const extractJSON = (response: string): string => {
 };
 
 const DebateRoom: React.FC = () => {
+  const judgingRef = useRef(false);
+  const navigate = useNavigate();
   const location = useLocation();
   const navigate = useNavigate();
   const debateData = location.state as DebateProps;

--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -7,6 +7,7 @@ import JudgmentPopup from "@/components/JudgementPopup";
 import { Mic, MicOff } from "lucide-react";
 import { useAtom } from "jotai";
 import { userAtom } from "@/state/userAtom";
+import JSON5 from "json5";
 
 // Bot type definition (same as in BotSelection)
 interface Bot {
@@ -597,16 +598,9 @@ const DebateRoom: React.FC = () => {
 
       let judgment: JudgmentData;
       try {
-        judgment = JSON.parse(jsonString);
-      } catch (parseError) {
-        console.error("JSON parse error:", parseError, "Trying to fix JSON...");
-        const fixedJson = jsonString
-          .replace(/'/g, '"')
-          .replace(/(\w+):/g, '"$1":')
-          .replace(/,\s*}/g, '}')
-          .replace(/,\s*]/g, ']');
-
-        judgment = JSON.parse(fixedJson);
+        judgment = JSON5.parse(jsonString);
+      }catch (e) {
+        throw new Error(`Failed to parse judgment JSON: ${e}`);
       }
 
       console.log("Parsed judgment:", judgment);

--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -7,8 +7,6 @@ import JudgmentPopup from "@/components/JudgementPopup";
 import { Mic, MicOff } from "lucide-react";
 import { useAtom } from "jotai";
 import { userAtom } from "@/state/userAtom";
-import { useNavigate } from "react-router-dom";
-
 
 // Bot type definition (same as in BotSelection)
 interface Bot {

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -57,21 +57,26 @@ function Header() {
 
   return (
     <>
-      <header className="flex items-center justify-between h-16 px-4 border-b border-gray-200">
-        <div className="text-lg font-semibold">{getBreadcrumbs()}</div>
+      <header className="flex items-center justify-between h-16 px-4 border-b border-border bg-background">
+        <div className="text-lg font-semibold text-foreground">
+          {getBreadcrumbs()}
+        </div>
+
         <div className="flex items-center gap-4">
           <button className="relative">
-            <Bell className="w-5 h-5 text-gray-600" />
-            <span className="absolute -top-1 -right-1 block h-2 w-2 rounded-full bg-red-500" />
+            <Bell className="w-5 h-5 text-muted-foreground" />
+            <span className="absolute -top-1 -right-1 block h-2 w-2 rounded-full bg-destructive" />
           </button>
+
           <img
             src={avatarImage}
             alt="User avatar"
-            className="w-8 h-8 rounded-full border-2 border-gray-300 object-cover"
+            className="w-8 h-8 rounded-full border-2 border-border object-cover"
           />
+
           <button
             onClick={toggleDrawer}
-            className="md:hidden p-2 rounded-md text-gray-600 hover:bg-gray-100"
+            className="md:hidden p-2 rounded-md text-muted-foreground hover:bg-muted"
             aria-label="Open menu"
           >
             <Menu className="h-6 w-6" />
@@ -82,13 +87,14 @@ function Header() {
       {isDrawerOpen && (
         <div className="fixed inset-0 z-[1000] md:hidden">
           <div
-            className="absolute inset-0 bg-black bg-opacity-50"
+            className="absolute inset-0 bg-black/50"
             onClick={toggleDrawer}
-          ></div>
-          <div className="relative w-64 h-full bg-white shadow-lg transform transition-transform duration-300 ease-in-out translate-x-0 ml-auto">
-            <div className="flex items-center justify-between h-16 px-4 border-b border-gray-200">
+          />
+
+          <div className="relative w-64 h-full bg-background border-l border-border shadow-lg ml-auto">
+            <div className="flex items-center justify-between h-16 px-4 border-b border-border">
               <div className="flex items-center gap-2">
-                <span className="text-xl font-bold text-gray-900">
+                <span className="text-xl font-bold text-foreground">
                   DebateAI by
                 </span>
                 <img
@@ -97,14 +103,16 @@ function Header() {
                   className="h-8 w-auto object-contain"
                 />
               </div>
+
               <button
                 onClick={toggleDrawer}
-                className="p-2 text-gray-600 hover:text-gray-900"
+                className="p-2 text-muted-foreground hover:text-foreground"
                 aria-label="Close menu"
               >
                 <X className="h-6 w-6" />
               </button>
             </div>
+
             <nav className="flex-1 px-2 py-4 space-y-2">
               <NavItem
                 to="/startDebate"
@@ -153,8 +161,8 @@ function NavItem({ to, label, icon, onClick }: NavItemProps) {
       className={({ isActive }) =>
         `group flex items-center px-2 py-2 text-sm font-medium rounded-md ${
           isActive
-            ? "bg-gray-200 text-gray-900"
-            : "text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+            ? "bg-muted text-foreground"
+            : "text-muted-foreground hover:bg-muted hover:text-foreground"
         }`
       }
     >
@@ -163,5 +171,6 @@ function NavItem({ to, label, icon, onClick }: NavItemProps) {
     </NavLink>
   );
 }
+
 
 export default Header;

--- a/frontend/src/components/JudgementPopup.tsx
+++ b/frontend/src/components/JudgementPopup.tsx
@@ -113,6 +113,7 @@ const JudgmentPopup: React.FC<JudgmentPopupProps> = ({
   botName,
   userStance,
   botStance,
+  botDesc,       
   forRole,
   againstRole,
   localRole = null,

--- a/frontend/src/components/Matchmaking.tsx
+++ b/frontend/src/components/Matchmaking.tsx
@@ -24,6 +24,8 @@ interface MatchmakingMessage {
   error?: string;
 }
 
+
+
 const Matchmaking: React.FC = () => {
   const [pool, setPool] = useState<MatchmakingPool[]>([]);
   const [isConnected, setIsConnected] = useState(false);
@@ -32,6 +34,13 @@ const Matchmaking: React.FC = () => {
   const { user, isLoading } = useUser();
   const wsRef = useRef<WebSocket | null>(null);
   const navigate = useNavigate();
+
+    // Reset matchmaking UI state on page refresh
+    useEffect(() => {
+      setIsInPool(false);
+      setWaitTime(0);
+    }, []);
+
 
   useEffect(() => {
     // If still loading, wait

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -115,7 +115,12 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none",
+      "text-foreground",
+      "data-[highlighted]:bg-muted data-[highlighted]:text-foreground",
+      "high-contrast:data-[highlighted]:bg-[hsl(var(--hc-hover-bg))]",
+      "high-contrast:data-[highlighted]:text-[hsl(var(--hc-hover-text))]",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}
@@ -125,10 +130,12 @@ const SelectItem = React.forwardRef<
         <CheckIcon className="h-4 w-4" />
       </SelectPrimitive.ItemIndicator>
     </span>
+
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
 ))
 SelectItem.displayName = SelectPrimitive.Item.displayName
+
 
 const SelectSeparator = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Separator>,

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -131,10 +131,13 @@ const SelectItem = React.forwardRef<
       </SelectPrimitive.ItemIndicator>
     </span>
 
-    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    <SelectPrimitive.ItemText>
+      {children}
+    </SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
 ))
 SelectItem.displayName = SelectPrimitive.Item.displayName
+
 
 
 const SelectSeparator = React.forwardRef<

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -85,6 +85,10 @@
     --chart-5: 180 100% 50%;
   }
 }
+.high-contrast {
+  --hc-hover-bg: 48 100% 50%;      
+  --hc-hover-text: 0 0% 0%;       
+}
 
 @layer base {
   * {


### PR DESCRIPTION
This PR fixes an issue where all debate rooms (bot mode and matchmaking chatroom) always rendered in light mode, even when global dark mode was enabled.
The rest of the application already correctly consumes the global ThemeProvider, but the debate module was overriding it with hard-coded light styles.
close #271 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Elo rating changes now tracked and shown per recent debate in your profile/history.

* **Bug Fixes**
  * Prevented duplicate judgment submissions with a concurrency guard.
  * Improved judgment parsing/error handling for clearer results.
  * Matchmaking UI now resets reliably on page refresh.

* **UI/UX**
  * Dark-mode and high-contrast styling improvements; updated theme tokens.
  * Navigation/routes reorganized for more consistent protected/layout behavior.
  * Minor dialog and header styling tweaks; judgment popup shows bot descriptions correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->