### PR TITLE
Enable Enter key to send debate messages

### DIFF
--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -860,6 +860,12 @@ const DebateRoom: React.FC = () => {
                   onChange={(e) =>
                     !isRecognizing && setFinalInput(e.target.value)
                   }
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && !e.shiftKey) {
+                      e.preventDefault();
+                      sendMessage();
+                    }
+                  }}
                   readOnly={isRecognizing}
                   disabled={
                     state.isBotTurn || state.timer === 0 || nextTurnPending


### PR DESCRIPTION
Closes #280 

### What changed

- Added Enter key handling to the debate message input
- Pressing Enter now sends the message
- Shift + Enter remains supported

### Why

Improves usability and matches standard chat behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut support for the debate room. Users can now send messages by pressing Enter, while Shift+Enter allows composing multiline messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->