### PR TITLE
Enable multiline textarea for better readability

### DIFF
--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Button } from "../components/ui/button";
-import { Input } from "../components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { sendDebateMessage, judgeDebate, concedeDebate } from "@/services/vsbot";
 import JudgmentPopup from "@/components/JudgementPopup";
 import { Mic, MicOff } from "lucide-react";
@@ -851,7 +851,7 @@ const DebateRoom: React.FC = () => {
             </div>
             {!state.isDebateEnded && (
               <div className="mt-3 flex gap-2 items-center">
-                <Input
+                <Textarea
                   value={
                     isRecognizing
                       ? finalInput + (interimInput ? " " + interimInput : "")

--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -860,6 +860,12 @@ const DebateRoom: React.FC = () => {
                   onChange={(e) =>
                     !isRecognizing && setFinalInput(e.target.value)
                   }
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && !e.shiftKey) {
+                      e.preventDefault();
+                      sendMessage();
+                    }
+                  }}
                   readOnly={isRecognizing}
                   disabled={
                     state.isBotTurn || state.timer === 0 || nextTurnPending


### PR DESCRIPTION
Closes #293 

### Summary
Replaced single-line input with textarea to improve readability while typing messages.

### Changes
- Replaced `<Input />` with `<Textarea />` in debate message box
- Enables multiline typing

### Screenshots

- Before

<img width="774" height="323" alt="Screenshot 2026-02-06 231734" src="https://github.com/user-attachments/assets/1d4e4005-2e1f-427d-a66f-fa3ba4c4a49d" />


- After

<img width="1579" height="913" alt="Screenshot 2026-02-06 185005" src="https://github.com/user-attachments/assets/d299ca7d-f1c1-4481-b432-767cb7f76a71" />

<img width="1582" height="904" alt="Screenshot 2026-02-06 185016" src="https://github.com/user-attachments/assets/46101dd7-e01e-4852-ad03-025b52932f61" />

- Video Link

https://drive.google.com/file/d/1D1t4MgKtR2C3fxbGmN0mfTDv5kRZVohc/view?usp=sharing

### Note
Enter key behavior is handled in a separate PR #292 
Also added enter key and shift + enter key behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Replaced the single-line message input with a multi-line textarea in the debate room to improve text entry.
  * Added keyboard behavior: pressing Enter (without Shift) sends the message while Shift+Enter inserts a newline.
  * Existing messaging, recognition, and send flow remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->