### PR TITLE
Unsafe JSON Parsing Leads to entire application will crash (White Screen of Death).

### DIFF
--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -226,18 +226,30 @@ const DebateRoom: React.FC = () => {
 
   const [state, setState] = useState<DebateState>(() => {
     const savedState = localStorage.getItem(debateKey);
-    return savedState
-      ? JSON.parse(savedState)
-      : {
-          messages: [],
-          currentPhase: 0,
-          phaseStep: 0,
-          isBotTurn: false,
-          userStance: "",
-          botStance: "",
-          timer: phases[0].time,
-          isDebateEnded: false,
-        };
+    // Define default state to avoid duplication
+    const defaultState = {
+      messages: [],
+      currentPhase: 0,
+      phaseStep: 0,
+      isBotTurn: false,
+      userStance: "",
+      botStance: "",
+      timer: phases[0].time,
+      isDebateEnded: false,
+    };
+
+    if (savedState) {
+      try {
+        return JSON.parse(savedState);
+      } catch (error) {
+        console.error("Failed to parse saved debate state:", error);
+        // Optional: clear the corrupted state so it doesn't persist
+        localStorage.removeItem(debateKey);
+        return defaultState;
+      }
+    }
+    
+    return defaultState;
   });
   const [finalInput, setFinalInput] = useState("");
   const [interimInput, setInterimInput] = useState("");


### PR DESCRIPTION
Added json parsing in Try catch block , see issue 
```
    if (savedState) {
      try {
        return JSON.parse(savedState);
      } catch (error) {
        console.error("Failed to parse saved debate state:", error);
        // Optional: clear the corrupted state so it doesn't persist
        localStorage.removeItem(debateKey);
        return defaultState;
      }
    }
    
```
    return defaultState;
  });
  Closes #300 
  
  @bhavik-mangla Please review , can be merged, let me know any issue 
  Thankyou

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debate room initialization to gracefully handle corrupted locally stored data, preventing crashes and automatically recovering to default settings while logging errors for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->