### PR TITLE
Fixing issue #301

### DIFF
--- a/backend/services/matchmaking.go
+++ b/backend/services/matchmaking.go
@@ -22,6 +22,7 @@ type MatchmakingPool struct {
 	JoinedAt           time.Time `json:"joinedAt" bson:"joinedAt"`
 	LastActivity       time.Time `json:"lastActivity" bson:"lastActivity"`
 	StartedMatchmaking bool      `json:"startedMatchmaking" bson:"startedMatchmaking"`
+	IsMatching         bool      `json:"-" bson:"-"` // New field to reserve users
 }
 
 // MatchmakingService handles the matchmaking logic
@@ -127,7 +128,9 @@ func (ms *MatchmakingService) GetPool() []MatchmakingPool {
 func (ms *MatchmakingService) findMatch(userID string) {
 	ms.mutex.Lock()
 	user, exists := ms.pool[userID]
-	if !exists || !user.StartedMatchmaking {
+	
+	// Skip if user doesn't exist, isn't searching, or is ALREADY being matched
+	if !exists || !user.StartedMatchmaking || user.IsMatching {
 		ms.mutex.Unlock()
 		return
 	}
@@ -138,8 +141,8 @@ func (ms *MatchmakingService) findMatch(userID string) {
 		if opponent.UserID == userID {
 			continue // Skip self
 		}
-		// Only consider opponents who have started matchmaking
-		if !opponent.StartedMatchmaking {
+		// Skip opponents who aren't searching or are already reserved
+		if !opponent.StartedMatchmaking || opponent.IsMatching {
 			continue
 		}
 		// Check if Elo ranges overlap
@@ -159,8 +162,10 @@ func (ms *MatchmakingService) findMatch(userID string) {
 	}
 	// Reserve/remove both under lock to avoid duplicate room creation
 	if bestMatch != nil {
-		delete(ms.pool, user.UserID)
-		delete(ms.pool, bestMatch.UserID)
+		// FIX: Reserve them instead of deleting
+		user.IsMatching = true
+		bestMatch.IsMatching = true
+
 		// Capture locals and unlock before I/O
 		u1, u2 := user, bestMatch
 		ms.mutex.Unlock()
@@ -179,6 +184,7 @@ func (ms *MatchmakingService) createRoomForMatch(user1, user2 *MatchmakingPool) 
 
 	// If DB is not initialized, skip persistence but still complete the match.
 	if db.MongoDatabase == nil {
+		// Test mode cleanup
 		ms.RemoveFromPool(user1.UserID)
 		ms.RemoveFromPool(user2.UserID)
 		if roomCreatedCallback != nil {
@@ -193,19 +199,11 @@ func (ms *MatchmakingService) createRoomForMatch(user1, user2 *MatchmakingPool) 
 		"_id":  roomID,
 		"type": "public",
 		"participants": []bson.M{
-			{
-				"id":       user1.UserID,
-				"username": user1.Username,
-				"elo":      user1.Elo,
-			},
-			{
-				"id":       user2.UserID,
-				"username": user2.Username,
-				"elo":      user2.Elo,
-			},
+			{"id": user1.UserID, "username": user1.Username, "elo": user1.Elo},
+			{"id": user2.UserID, "username": user2.Username, "elo": user2.Elo},
 		},
 		"createdAt": time.Now(),
-		"status":    "waiting", // waiting, active, completed
+		"status":    "waiting",
 	}
 	// Insert the room directly
 	_, err := roomCollection.InsertOne(ctx, room)
@@ -219,12 +217,13 @@ func (ms *MatchmakingService) createRoomForMatch(user1, user2 *MatchmakingPool) 
 	// Remove both users from the pool
 	ms.RemoveFromPool(user1.UserID)
 	ms.RemoveFromPool(user2.UserID)
-	// Broadcast room creation to WebSocket clients
-	participantUserIDs := []string{user1.UserID, user2.UserID}
+
 	if roomCreatedCallback != nil {
+		participantUserIDs := []string{user1.UserID, user2.UserID}
 		roomCreatedCallback(roomID, participantUserIDs)
 	}
-}
+
+	}
 
 // cleanupInactiveUsers removes users who have been inactive for too long
 func (ms *MatchmakingService) cleanupInactiveUsers() {

--- a/backend/services/matchmaking.go
+++ b/backend/services/matchmaking.go
@@ -207,13 +207,13 @@ func (ms *MatchmakingService) createRoomForMatch(user1, user2 *MatchmakingPool) 
 	}
 	// Insert the room directly
 	_, err := roomCollection.InsertOne(ctx, room)
-	if err != nil {
-		ms.mutex.Lock()
-		ms.pool[user1.UserID] = user1
-		ms.pool[user2.UserID] = user2
-		ms.mutex.Unlock()
-		return
-	}
+	 	if err != nil {
+ 		ms.mutex.Lock()
+		user1.IsMatching = false
+		user2.IsMatching = false
+ 		ms.mutex.Unlock()
+ 		return
+ 	}
 	// Remove both users from the pool
 	ms.RemoveFromPool(user1.UserID)
 	ms.RemoveFromPool(user2.UserID)


### PR DESCRIPTION
**Solved issue** : the "Matchmaking Limbo" race condition, we need to change the logic so users are not removed from the pool until the room is successfully created in the database. Instead, we will mark them as IsMatching.

### Fix Strategy: "Reserve" before "Remove"

- **Add State**: Add an IsMatching flag to the user struct.

1. Reserve: In findMatch, set IsMatching = true (locking the users) instead of deleting them.

1. Commit/Rollback: In createRoomForMatch, delete them on success, or reset IsMatching = false on failure.

Video or screenshot : N/A  logical changes

@bhavik-mangla  closes #301 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved matchmaking reliability by preventing users from being re-selected during the matching process.
  * Enhanced eligibility checks to ensure only appropriate candidates are matched.
  * Fixed room creation flow to properly handle matched player reservations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->