### PR TITLE
Fix blank screen after debate judgment by adding defensive UI guards

### DIFF
--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -619,7 +619,7 @@ function DebateRoomInner({ debateData }: { debateData: DebateProps }) {
         // Try to fix common JSON issues
         const fixedJson = jsonString
           .replace(/'/g, '"') // Replace single quotes with double quotes
-          .replace(/(\w+):/g, '"$1":') // Add quotes to keys
+          .replace(/(?<=[\{,]\s*)(\w+)\s*:/g, '"$1":') // Only quote keys after { or ,
           .replace(/,\s*}/g, '}') // Remove trailing commas
           .replace(/,\s*]/g, ']'); // Remove trailing commas in arrays
         try {
@@ -743,7 +743,7 @@ function DebateRoomInner({ debateData }: { debateData: DebateProps }) {
           <div className="bg-white rounded-xl shadow-2xl p-6 max-w-md w-full transform transition-all duration-300 scale-105 border border-orange-200">
             {popup.isJudging ? (
               <div className="flex flex-col items-center">
-                <div className="animate-spin rounded-full h-16 w-16 border-t-4 border-blue500 mb-4"></div>
+                <div className="animate-spin rounded-full h-16 w-16 border-t-4 border-blue-500 mb-4"></div>
                 <h2 className="text-xl font-semibold text-gray-800">
                   {popup.message}
                 </h2>

--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -254,7 +254,25 @@ function DebateRoomInner({ debateData }: { debateData: DebateProps }) {
     const savedState = localStorage.getItem(debateKey);
     if (savedState) {
       try {
-        return JSON.parse(savedState);
+        const parsed = JSON.parse(savedState);
+        if (
+          parsed &&
+          Array.isArray(parsed.messages) &&
+          typeof parsed.currentPhase === "number" &&
+          parsed.currentPhase >= 0 &&
+          parsed.currentPhase < (phases?.length || 1) &&
+          typeof parsed.phaseStep === "number" &&
+          parsed.phaseStep >= 0 &&
+          typeof parsed.timer === "number" &&
+          typeof parsed.isBotTurn === "boolean" &&
+          typeof parsed.isDebateEnded === "boolean" &&
+          typeof parsed.userStance === "string" &&
+          typeof parsed.botStance === "string"
+        ) {
+          return parsed as DebateState;
+        }
+        console.warn("Stale/invalid debate state in localStorage, resetting.");
+        localStorage.removeItem(debateKey);
       } catch (e) {
         console.warn("Corrupted debate state in localStorage, resetting.");
         localStorage.removeItem(debateKey);

--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useRef } from "react";
+import * as React from "react";
+import { useState, useEffect, useRef } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
@@ -197,20 +198,20 @@ const turnTypes = [
 
 const extractJSON = (response: string): string => {
   if (!response) return "{}";
-  
+
   // Try to extract JSON from markdown code fences
   const fenceRegex = /```(?:json)?\s*([\s\S]*?)\s*```/;
   const match = fenceRegex.exec(response);
   if (match && match[1]) {
     return match[1].trim();
   }
-  
+
   // Try to find JSON object in the response
   const jsonMatch = response.match(/\{[\s\S]*\}/);
   if (jsonMatch) {
     return jsonMatch[0];
   }
-  
+
   // If no JSON found, return empty object
   console.warn("No JSON found in response:", response);
   return "{}";
@@ -219,7 +220,27 @@ const extractJSON = (response: string): string => {
 const DebateRoom: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
-  const debateData = location.state as DebateProps;
+  const debateData = location.state as DebateProps | null;
+
+  // Redirect if no debate data exists (prevents blank screen crash)
+  useEffect(() => {
+    if (!debateData) {
+      navigate('/game');
+    }
+  }, [debateData, navigate]);
+
+  // Early return if no debate data (show loading while redirecting)
+  if (!debateData) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-200 flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-t-4 border-orange-500 mx-auto mb-4"></div>
+          <p className="text-gray-600">No debate data found. Redirecting...</p>
+        </div>
+      </div>
+    );
+  }
+
   const phases = debateData.phaseTimings;
   const debateKey = `debate_${debateData.userId}_${debateData.topic}_${debateData.debateId}`;
   const [user] = useAtom(userAtom);
@@ -229,15 +250,15 @@ const DebateRoom: React.FC = () => {
     return savedState
       ? JSON.parse(savedState)
       : {
-          messages: [],
-          currentPhase: 0,
-          phaseStep: 0,
-          isBotTurn: false,
-          userStance: "",
-          botStance: "",
-          timer: phases[0].time,
-          isDebateEnded: false,
-        };
+        messages: [],
+        currentPhase: 0,
+        phaseStep: 0,
+        isBotTurn: false,
+        userStance: "",
+        botStance: "",
+        timer: phases[0].time,
+        isDebateEnded: false,
+      };
   });
   const [finalInput, setFinalInput] = useState("");
   const [interimInput, setInterimInput] = useState("");
@@ -263,18 +284,18 @@ const DebateRoom: React.FC = () => {
     if (window.confirm("Are you sure you want to concede? This will count as a loss.")) {
       try {
         if (debateData.debateId) {
-            await concedeDebate(debateData.debateId, state.messages);
+          await concedeDebate(debateData.debateId, state.messages);
         }
-        
+
         setState(prev => ({ ...prev, isDebateEnded: true }));
         setPopup({
-            show: true,
-            message: "You have conceded the debate.",
-            isJudging: false
+          show: true,
+          message: "You have conceded the debate.",
+          isJudging: false
         });
-        
+
         setTimeout(() => {
-            navigate("/game");
+          navigate("/game");
         }, 2000);
 
       } catch (error) {
@@ -360,7 +381,7 @@ const DebateRoom: React.FC = () => {
     if (!state.userStance) {
       const stanceNormalized =
         debateData.stance.toLowerCase() === "for" ||
-        debateData.stance.toLowerCase() === "against"
+          debateData.stance.toLowerCase() === "against"
           ? debateData.stance.toLowerCase() === "for"
             ? "For"
             : "Against"
@@ -451,9 +472,8 @@ const DebateRoom: React.FC = () => {
       const newPhase = currentState.currentPhase + 1;
       setPopup({
         show: true,
-        message: `${phases[currentState.currentPhase].name} completed. Next: ${
-          phases[newPhase].name
-        } - ${getPhaseInstructions(newPhase)}`,
+        message: `${phases[currentState.currentPhase].name} completed. Next: ${phases[newPhase].name
+          } - ${getPhaseInstructions(newPhase)}`,
       });
       setTimeout(() => {
         setPopup({ show: false, message: "" });
@@ -582,10 +602,10 @@ const DebateRoom: React.FC = () => {
         userId: debateData.userId,
       });
       console.log("Raw judge result:", result);
-      
+
       const jsonString = extractJSON(result);
       console.log("Extracted JSON string:", jsonString);
-      
+
       let judgment: JudgmentData;
       try {
         judgment = JSON.parse(jsonString);
@@ -603,7 +623,7 @@ const DebateRoom: React.FC = () => {
           throw new Error(`Failed to parse JSON: ${e}`);
         }
       }
-      
+
       console.log("Parsed judgment:", judgment);
       setJudgmentData(judgment);
       setPopup({ show: false, message: "" });
@@ -616,7 +636,7 @@ const DebateRoom: React.FC = () => {
         message: `Judgment error: ${error instanceof Error ? error.message : "Unknown error"}. Showing default results.`,
         isJudging: false,
       });
-      
+
       // Set default judgment data
       setJudgmentData({
         opening_statement: {
@@ -656,9 +676,8 @@ const DebateRoom: React.FC = () => {
       .padStart(2, "0")}`;
     return (
       <span
-        className={`font-mono ${
-          seconds <= 5 ? "text-red-500 animate-pulse" : "text-gray-600"
-        }`}
+        className={`font-mono ${seconds <= 5 ? "text-red-500 animate-pulse" : "text-gray-600"
+          }`}
       >
         {timeStr}
       </span>
@@ -707,8 +726,8 @@ const DebateRoom: React.FC = () => {
               {currentTurnType === "statement"
                 ? "make a statement"
                 : currentTurnType === "question"
-                ? "ask a question"
-                : "answer"}
+                  ? "ask a question"
+                  : "answer"}
             </span>
           </p>
         </div>
@@ -754,9 +773,8 @@ const DebateRoom: React.FC = () => {
       <div className="w-full max-w-5xl mx-auto flex flex-col md:flex-row gap-3">
         {/* Bot Section */}
         <div
-          className={`relative w-full md:w-1/2 ${
-            state.isBotTurn ? "animate-glow" : ""
-          } bg-white border border-gray-200 shadow-md h-[540px] flex flex-col`}
+          className={`relative w-full md:w-1/2 ${state.isBotTurn ? "animate-glow" : ""
+            } bg-white border border-gray-200 shadow-md h-[540px] flex flex-col`}
         >
           <div className="p-2 bg-gray-50 flex items-center gap-2">
             <div className="w-12 h-12 flex-shrink-0">
@@ -802,9 +820,8 @@ const DebateRoom: React.FC = () => {
 
         {/* User Section */}
         <div
-          className={`relative w-full md:w-1/2 ${
-            !state.isBotTurn && !state.isDebateEnded ? "animate-glow" : ""
-          } bg-white border border-gray-200 shadow-md h-[540px] flex flex-col`}
+          className={`relative w-full md:w-1/2 ${!state.isBotTurn && !state.isDebateEnded ? "animate-glow" : ""
+            } bg-white border border-gray-200 shadow-md h-[540px] flex flex-col`}
         >
           <div className="p-2 bg-gray-50 flex items-center gap-2">
             <div className="w-12 h-12 flex-shrink-0">
@@ -868,8 +885,8 @@ const DebateRoom: React.FC = () => {
                     currentTurnType === "statement"
                       ? "Make your statement"
                       : currentTurnType === "question"
-                      ? "Ask your question"
-                      : "Provide your answer"
+                        ? "Ask your question"
+                        : "Provide your answer"
                   }
                   className="flex-1 rounded-md text-sm border border-border bg-input text-foreground placeholder:text-muted-foreground focus:border-orange-400"
                 />

--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -225,7 +225,7 @@ const DebateRoom: React.FC = () => {
 
   useEffect(() => {
     if (!debateData) {
-      navigate('/game');
+      navigate('/game', { replace: true });
     }
   }, [debateData, navigate]);
 
@@ -252,18 +252,24 @@ function DebateRoomInner({ debateData }: { debateData: DebateProps }) {
 
   const [state, setState] = useState<DebateState>(() => {
     const savedState = localStorage.getItem(debateKey);
-    return savedState
-      ? JSON.parse(savedState)
-      : {
-        messages: [],
-        currentPhase: 0,
-        phaseStep: 0,
-        isBotTurn: false,
-        userStance: "",
-        botStance: "",
-        timer: phases[0].time,
-        isDebateEnded: false,
-      };
+    if (savedState) {
+      try {
+        return JSON.parse(savedState);
+      } catch (e) {
+        console.warn("Corrupted debate state in localStorage, resetting.");
+        localStorage.removeItem(debateKey);
+      }
+    }
+    return {
+      messages: [],
+      currentPhase: 0,
+      phaseStep: 0,
+      isBotTurn: false,
+      userStance: "",
+      botStance: "",
+      timer: phases[0].time,
+      isDebateEnded: false,
+    };
   });
   const [finalInput, setFinalInput] = useState("");
   const [interimInput, setInterimInput] = useState("");
@@ -619,7 +625,7 @@ function DebateRoomInner({ debateData }: { debateData: DebateProps }) {
         // Try to fix common JSON issues
         const fixedJson = jsonString
           .replace(/'/g, '"') // Replace single quotes with double quotes
-          .replace(/(?<=[\{,]\s*)(\w+)\s*:/g, '"$1":') // Only quote keys after { or ,
+          .replace(/([\{,]\s*)(\w+)\s*:/g, '$1"$2":') // Quote unquoted keys after { or ,
           .replace(/,\s*}/g, '}') // Remove trailing commas
           .replace(/,\s*]/g, ']'); // Remove trailing commas in arrays
         try {

--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -267,7 +267,7 @@ function DebateRoomInner({ debateData }: { debateData: DebateProps }) {
       isBotTurn: false,
       userStance: "",
       botStance: "",
-      timer: phases[0].time,
+      timer: phases?.[0]?.time ?? 60,
       isDebateEnded: false,
     };
   });
@@ -306,7 +306,7 @@ function DebateRoomInner({ debateData }: { debateData: DebateProps }) {
         });
 
         setTimeout(() => {
-          navigate("/game");
+          navigate("/game", { replace: true });
         }, 2000);
 
       } catch (error) {

--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -217,19 +217,18 @@ const extractJSON = (response: string): string => {
   return "{}";
 };
 
+// Wrapper component to handle missing state (safe for hooks)
 const DebateRoom: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const debateData = location.state as DebateProps | null;
 
-  // Redirect if no debate data exists (prevents blank screen crash)
   useEffect(() => {
     if (!debateData) {
       navigate('/game');
     }
   }, [debateData, navigate]);
 
-  // Early return if no debate data (show loading while redirecting)
   if (!debateData) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-200 flex items-center justify-center">
@@ -241,6 +240,12 @@ const DebateRoom: React.FC = () => {
     );
   }
 
+  return <DebateRoomInner debateData={debateData} />;
+};
+
+// Inner component with all hooks (safe - no early returns before hooks)
+function DebateRoomInner({ debateData }: { debateData: DebateProps }) {
+  const navigate = useNavigate();
   const phases = debateData.phaseTimings;
   const debateKey = `debate_${debateData.userId}_${debateData.topic}_${debateData.debateId}`;
   const [user] = useAtom(userAtom);
@@ -936,6 +941,6 @@ const DebateRoom: React.FC = () => {
       `}</style>
     </div>
   );
-};
+}
 
 export default DebateRoom;

--- a/frontend/src/components/JudgementPopup.tsx
+++ b/frontend/src/components/JudgementPopup.tsx
@@ -133,102 +133,106 @@ const JudgmentPopup: React.FC<JudgmentPopupProps> = ({
     localStorage.getItem('opponentAvatar') ||
     'https://avatar.iran.liara.run/public/31';
 
-const isUserBotFormat = 'user' in judgment.opening_statement;
+  const isUserBotFormat = judgment?.opening_statement && 'user' in judgment.opening_statement;
 
-const defaultForName = forRole || 'For Debater';
-const defaultAgainstName = againstRole || 'Against Debater';
-const resolvedLocalName = localDisplayName || userName;
-const resolvedOpponentName = opponentDisplayName || 'Opponent';
-const derivedLocalAvatar = localAvatarUrl || localAvatar;
-const derivedOpponentAvatar = opponentAvatarUrl || opponentAvatar;
+  const defaultForName = forRole || 'For Debater';
+  const defaultAgainstName = againstRole || 'Against Debater';
+  const resolvedLocalName = localDisplayName || userName;
+  const resolvedOpponentName = opponentDisplayName || 'Opponent';
+  const derivedLocalAvatar = localAvatarUrl || localAvatar;
+  const derivedOpponentAvatar = opponentAvatarUrl || opponentAvatar;
 
-const resolvedForName = isUserBotFormat
-  ? defaultForName
-  : localRole === 'for'
-  ? resolvedLocalName
-  : localRole === 'against'
-  ? resolvedOpponentName
-  : defaultForName;
+  const resolvedForName = isUserBotFormat
+    ? defaultForName
+    : localRole === 'for'
+      ? resolvedLocalName
+      : localRole === 'against'
+        ? resolvedOpponentName
+        : defaultForName;
 
-const resolvedAgainstName = isUserBotFormat
-  ? defaultAgainstName
-  : localRole === 'against'
-  ? resolvedLocalName
-  : localRole === 'for'
-  ? resolvedOpponentName
-  : defaultAgainstName;
+  const resolvedAgainstName = isUserBotFormat
+    ? defaultAgainstName
+    : localRole === 'against'
+      ? resolvedLocalName
+      : localRole === 'for'
+        ? resolvedOpponentName
+        : defaultAgainstName;
 
-const player1Name = isUserBotFormat ? userName : resolvedForName;
-const player2Name = isUserBotFormat ? botName || 'Bot' : resolvedAgainstName;
-const player1Stance = isUserBotFormat ? userStance : 'For';
-const player2Stance = isUserBotFormat ? botStance : 'Against';
+  const player1Name = isUserBotFormat ? userName : resolvedForName;
+  const player2Name = isUserBotFormat ? botName || 'Bot' : resolvedAgainstName;
+  const player1Stance = isUserBotFormat ? userStance : 'For';
+  const player2Stance = isUserBotFormat ? botStance : 'Against';
 
-const resolvedForAvatar = isUserBotFormat
-  ? userAvatar
-  : localRole === 'for'
-  ? derivedLocalAvatar
-  : localRole === 'against'
-  ? derivedOpponentAvatar
-  : derivedLocalAvatar || derivedOpponentAvatar;
+  const resolvedForAvatar = isUserBotFormat
+    ? userAvatar
+    : localRole === 'for'
+      ? derivedLocalAvatar
+      : localRole === 'against'
+        ? derivedOpponentAvatar
+        : derivedLocalAvatar || derivedOpponentAvatar;
 
-const resolvedAgainstAvatar = isUserBotFormat
-  ? botAvatar
-  : localRole === 'against'
-  ? derivedLocalAvatar
-  : localRole === 'for'
-  ? derivedOpponentAvatar
-  : derivedOpponentAvatar || derivedLocalAvatar;
+  const resolvedAgainstAvatar = isUserBotFormat
+    ? botAvatar
+    : localRole === 'against'
+      ? derivedLocalAvatar
+      : localRole === 'for'
+        ? derivedOpponentAvatar
+        : derivedOpponentAvatar || derivedLocalAvatar;
 
-const player1Avatar = resolvedForAvatar || localAvatar;
-const player2Avatar = resolvedAgainstAvatar || opponentAvatar;
-const player2Desc = isUserBotFormat ? botDesc : resolvedAgainstName || 'Debater';
+  const player1Avatar = resolvedForAvatar || localAvatar;
+  const player2Avatar = resolvedAgainstAvatar || opponentAvatar;
+  const player2Desc = isUserBotFormat ? botDesc : resolvedAgainstName || 'Debater';
 
-const formatChange = (value: number) =>
-  `${value >= 0 ? '+' : ''}${value.toFixed(2)}`;
-const formatRating = (value: number) => value.toFixed(2);
+  const formatChange = (value: number) =>
+    `${value >= 0 ? '+' : ''}${value.toFixed(2)}`;
+  const formatRating = (value: number) => value.toFixed(2);
 
-const player1RatingSummary =
-  !isUserBotFormat && ratingSummary ? ratingSummary.for : null;
-const player2RatingSummary =
-  !isUserBotFormat && ratingSummary ? ratingSummary.against : null;
+  const player1RatingSummary =
+    !isUserBotFormat && ratingSummary ? ratingSummary.for : null;
+  const player2RatingSummary =
+    !isUserBotFormat && ratingSummary ? ratingSummary.against : null;
 
   const handleGoHome = () => {
     navigate('/startdebate');
   };
 
-  // Helper function to safely access scores and reasons
+  // Helper function to safely access scores and reasons with defensive checks
   const getScoreAndReason = (
     section: string,
     player: 'player1' | 'player2'
   ) => {
+    const defaultResult = { score: 0, reason: 'Data not available' };
+
+    if (!judgment) return defaultResult;
+
     if (isUserBotFormat) {
       const data = judgment as JudgmentDataUserBot;
       const key = player === 'player1' ? 'user' : 'bot';
       switch (section) {
         case 'opening_statement':
           return {
-            score: data.opening_statement[key].score,
-            reason: data.opening_statement[key].reason,
+            score: data.opening_statement?.[key]?.score ?? 0,
+            reason: data.opening_statement?.[key]?.reason ?? 'Data not available',
           };
         case 'cross_examination':
           return {
-            score: data.cross_examination[key].score,
-            reason: data.cross_examination[key].reason,
+            score: data.cross_examination?.[key]?.score ?? 0,
+            reason: data.cross_examination?.[key]?.reason ?? 'Data not available',
           };
         case 'answers':
           return {
-            score: data.answers[key].score,
-            reason: data.answers[key].reason,
+            score: data.answers?.[key]?.score ?? 0,
+            reason: data.answers?.[key]?.reason ?? 'Data not available',
           };
         case 'closing':
           return {
-            score: data.closing[key].score,
-            reason: data.closing[key].reason,
+            score: data.closing?.[key]?.score ?? 0,
+            reason: data.closing?.[key]?.reason ?? 'Data not available',
           };
         case 'total':
-          return { score: data.total[key], reason: '' };
+          return { score: data.total?.[key] ?? 0, reason: '' };
         default:
-          return { score: 0, reason: 'Data not available' };
+          return defaultResult;
       }
     } else {
       const data = judgment as JudgmentDataForAgainst;
@@ -236,28 +240,28 @@ const player2RatingSummary =
       switch (section) {
         case 'opening_statement':
           return {
-            score: data.opening_statement[key].score,
-            reason: data.opening_statement[key].reason,
+            score: data.opening_statement?.[key]?.score ?? 0,
+            reason: data.opening_statement?.[key]?.reason ?? 'Data not available',
           };
         case 'cross_examination_questions':
           return {
-            score: data.cross_examination_questions[key].score,
-            reason: data.cross_examination_questions[key].reason,
+            score: data.cross_examination_questions?.[key]?.score ?? 0,
+            reason: data.cross_examination_questions?.[key]?.reason ?? 'Data not available',
           };
         case 'cross_examination_answers':
           return {
-            score: data.cross_examination_answers[key].score,
-            reason: data.cross_examination_answers[key].reason,
+            score: data.cross_examination_answers?.[key]?.score ?? 0,
+            reason: data.cross_examination_answers?.[key]?.reason ?? 'Data not available',
           };
         case 'closing':
           return {
-            score: data.closing[key].score,
-            reason: data.closing[key].reason,
+            score: data.closing?.[key]?.score ?? 0,
+            reason: data.closing?.[key]?.reason ?? 'Data not available',
           };
         case 'total':
-          return { score: data.total[key], reason: '' };
+          return { score: data.total?.[key] ?? 0, reason: '' };
         default:
-          return { score: 0, reason: 'Data not available' };
+          return defaultResult;
       }
     }
   };
@@ -283,15 +287,15 @@ const player2RatingSummary =
       cross_questions: isUserBotFormat
         ? getScoreAndReason('cross_examination', 'player1').reason.toLowerCase()
         : getScoreAndReason(
-            'cross_examination_questions',
-            'player1'
-          ).reason.toLowerCase(),
+          'cross_examination_questions',
+          'player1'
+        ).reason.toLowerCase(),
       cross_answers: isUserBotFormat
         ? getScoreAndReason('answers', 'player1').reason.toLowerCase()
         : getScoreAndReason(
-            'cross_examination_answers',
-            'player1'
-          ).reason.toLowerCase(),
+          'cross_examination_answers',
+          'player1'
+        ).reason.toLowerCase(),
       closing: getScoreAndReason('closing', 'player1').reason.toLowerCase(),
     };
 
@@ -650,11 +654,10 @@ const player2RatingSummary =
                   </span>
                 </p>
                 <p
-                  className={`text-sm font-semibold ${
-                    player1RatingSummary.change >= 0
+                  className={`text-sm font-semibold ${player1RatingSummary.change >= 0
                       ? 'text-green-600'
                       : 'text-red-600'
-                  }`}
+                    }`}
                 >
                   Change: {formatChange(player1RatingSummary.change)}
                 </p>
@@ -670,11 +673,10 @@ const player2RatingSummary =
                   </span>
                 </p>
                 <p
-                  className={`text-sm font-semibold ${
-                    player2RatingSummary.change >= 0
+                  className={`text-sm font-semibold ${player2RatingSummary.change >= 0
                       ? 'text-green-600'
                       : 'text-red-600'
-                  }`}
+                    }`}
                 >
                   Change: {formatChange(player2RatingSummary.change)}
                 </p>
@@ -687,11 +689,11 @@ const player2RatingSummary =
         <div className='mt-10 bg-gradient-to-r from-orange-500 to-orange-600 p-6 rounded-lg shadow-md text-white text-center'>
           <h3 className='text-2xl font-bold'>Verdict</h3>
           <p className='mt-4 text-3xl font-bold'>
-            {judgment.verdict.winner} Wins!
+            {judgment?.verdict?.winner ?? 'Unknown'} Wins!
           </p>
-          <p className='mt-3 text-lg'>{judgment.verdict.congratulations}</p>
+          <p className='mt-3 text-lg'>{judgment?.verdict?.congratulations ?? ''}</p>
           <p className='mt-2 text-md leading-relaxed'>
-            {judgment.verdict.opponent_analysis}
+            {judgment?.verdict?.opponent_analysis ?? ''}
           </p>
         </div>
 


### PR DESCRIPTION
 Fix: Blank Screen After Debate Judgment

Problem:
After completing a User vs Bot debate, the backend successfully returns the judgment JSON. However, the frontend crashes and shows a blank blue screen instead of rendering results.

Root Cause:

DebateRoom.tsx assumes location.state always exists and crashes when it is null
JudgementPopup.tsx accesses deeply nested judgment properties without defensive checks

Solution:

Added a safe guard for missing location.state with redirect handling
Made JudgementPopup fully defensive using optional chaining and fallbacks
Prevented render-time crashes when judgment data is delayed or partially missing

Result:

Judgment UI now renders reliably
No more blank screen after scoring
Backend logic remains unchanged

Closes #306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Missing debate data now triggers an automatic redirect to the game page with a loading/redirect UI.
  * Judgment displays handle incomplete or missing data safely, avoiding runtime errors and showing sensible fallbacks.
  * Robust parsing of saved state: corrupted local storage falls back to defaults and logs a warning.
  * Minor UI/formatting tweaks to buttons, messages, and conditional styling for more consistent rendering.

* **Refactor**
  * Internal component structure reorganized to improve hook usage and maintain behavior (no public API changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->