### PR TITLE
chore: add scaffold for post-debate reasoning analysis module

### DIFF
--- a/backend/internal/analysis/README.md
+++ b/backend/internal/analysis/README.md
@@ -1,0 +1,27 @@
+# Post-Debate Analysis Module (Scaffold)
+
+This module introduces a foundation for future post-debate reasoning analysis in DebateAI.
+
+## Purpose
+
+The goal is to support structured reasoning diagnostics after a debate concludes,
+without modifying:
+
+- Debate flow
+- AI opponent behavior
+- Judging logic
+- Elo or ranking systems
+
+## Scope (Current Phase)
+
+This PR only introduces:
+- Interface definitions
+- Data structures
+- Module scaffolding
+
+No runtime behavior is changed.
+
+Future PRs may incrementally implement:
+- Fallacy signal detection
+- Explainable coaching
+- Reasoning metadata storage

--- a/backend/internal/analysis/analysis.go
+++ b/backend/internal/analysis/analysis.go
@@ -1,0 +1,7 @@
+package analysis
+
+// PostDebateAnalyzer defines the contract for future reasoning analysis modules.
+// It is intentionally minimal and does not alter any existing debate flow.
+type PostDebateAnalyzer interface {
+	Analyze(transcript interface{}) (*AnalysisResult, error)
+}

--- a/backend/internal/analysis/types.go
+++ b/backend/internal/analysis/types.go
@@ -1,0 +1,14 @@
+package analysis
+
+// FallacySignal represents a detected reasoning issue in a debate.
+type FallacySignal struct {
+	Type        string // e.g., "Ad Hominem", "False Dilemma"
+	Phase       string // opening, cross-exam, closing
+	Explanation string // why this weakens the argument
+}
+
+// AnalysisResult stores the output of post-debate reasoning analysis.
+type AnalysisResult struct {
+	DebateID string
+	Signals  []FallacySignal
+}


### PR DESCRIPTION
This PR introduces a non-invasive scaffold for a future post-debate reasoning analysis system.

What this includes:
- New internal package: backend/internal/analysis
- PostDebateAnalyzer interface
- FallacySignal and AnalysisResult types
- Documentation outlining intended future extensions

Important:
- No existing debate flow is modified
- No database changes
- No performance impact
- No external dependencies added

This lays the groundwork for future PRs that will introduce:
- Fallacy detection signals
- Explainable reasoning feedback
- Post-debate coaching improvements



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal infrastructure scaffolding added to support future debate analysis and reasoning diagnostics capabilities. No changes to existing functionality or user-visible features in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->