### PR TITLE
feat: update branding to Argue-Hub: #57

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,9 +8,9 @@
       href="https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap"
       rel="stylesheet"
     />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/png" href="/arguehub.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Argue-Hub</title>
     <script src="https://accounts.google.com/gsi/client" async defer></script>
   </head>
   <body>


### PR DESCRIPTION

**### Description**

This PR updates the website branding by replacing the default Vite template configuration with Argue-Hub branding.

Updated page title from "Vite + React + TS" to "Argue-Hub" (visible in the browser tab)

Updated favicon configuration to reference /arguehub.png

Removed the old vite.svg favicon reference

**### Note: The favicon link is configured and ready. Adding the arguehub.png file to the /public directory will complete the branding update.**

### **Changes**

index.html — Updated <title> tag and <link rel="icon"> to reference new favicon path

Fixes #57

### **Screenshots:**
<img width="781" height="308" alt="image" src="https://github.com/user-attachments/assets/5d25a23c-7b73-4ce8-a8b5-a501b2b133d8" />

**### Checklist:**

-  My PR addresses a single issue
-  My code follows the project's code style
-  My changes generate no new warnings or errors
-  I have read the Contribution Guidelines



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated page favicon and title branding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->