### PR TITLE
Web Speech API continuous mode stops automatically after silence

### DIFF
--- a/backend/config/config.prod.sample.yml
+++ b/backend/config/config.prod.sample.yml
@@ -2,7 +2,7 @@ server:
   port: 1313 # The port number your backend server will run on
 
 database:
-  uri: "mongodb+srv://<username>:<password>@<cluster-url>/<database-name>"
+  uri: mongodb://localhost:27017/debateai
   # Replace with your MongoDB Atlas connection string
   # Get this from your MongoDB Atlas dashboard after creating a cluster and database
 
@@ -12,7 +12,7 @@ gemini:
   # Obtain from your OpenRouter.ai or OpenAI account dashboard
 
 jwt:
-  secret: "<YOUR_JWT_SECRET>"
+  secret: "debateai_secret_key_123"
   # A secret string used to sign JWT tokens
   # Generate a strong random string (e.g. use `openssl rand -hex 32`)
 

--- a/backend/config/config.prod.sample.yml
+++ b/backend/config/config.prod.sample.yml
@@ -2,7 +2,7 @@ server:
   port: 1313 # The port number your backend server will run on
 
 database:
-  uri: mongodb://localhost:27017/debateai
+  uri: "mongodb+srv://<username>:<password>@<cluster-url>/<database-name>"
   # Replace with your MongoDB Atlas connection string
   # Get this from your MongoDB Atlas dashboard after creating a cluster and database
 
@@ -12,7 +12,7 @@ gemini:
   # Obtain from your OpenRouter.ai or OpenAI account dashboard
 
 jwt:
-  secret: "debateai_secret_key_123"
+  secret: "<YOUR_JWT_SECRET>"
   # A secret string used to sign JWT tokens
   # Generate a strong random string (e.g. use `openssl rand -hex 32`)
 

--- a/backend/controllers/debatevsbot_controller.go
+++ b/backend/controllers/debatevsbot_controller.go
@@ -267,16 +267,18 @@ func JudgeDebate(c *gin.Context) {
 	}
 
 	// Save transcript with proper debate information
-	_ = services.SaveDebateTranscript(
-		userID,
-		email,
-		"user_vs_bot",
-		latestDebate.Topic,
-		latestDebate.BotName,
-		resultStatus,
-		req.History,
+	services.SaveDebateTranscript(
+		user.ID,
+		user.Email,
+		"user_vs_ai",
+		topic,
+		"AI",
+		result,
+		messages,
 		nil,
+		0.0,
 	)
+
 
 	// Update gamification (score, badges, streaks) after bot debate
 	log.Printf("About to call updateGamificationAfterBotDebate for user %s, result: %s, topic: %s",

--- a/backend/controllers/profile_controller.go
+++ b/backend/controllers/profile_controller.go
@@ -254,7 +254,7 @@ func GetProfile(c *gin.Context) {
 				"opponent":   transcript.Opponent,
 				"debateType": transcript.DebateType,
 				"date":       transcript.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
-				"eloChange":  0, // TODO: Add actual Elo change tracking
+				"eloChange": transcript.EloChange,// TODO: Add actual Elo change tracking
 			})
 		}
 

--- a/backend/models/transcript.go
+++ b/backend/models/transcript.go
@@ -30,11 +30,13 @@ type SavedDebateTranscript struct {
 	Topic       string             `bson:"topic" json:"topic"`
 	Opponent    string             `bson:"opponent" json:"opponent"` // Bot name or opponent email
 	Result      string             `bson:"result" json:"result"`     // "win", "loss", "draw", "pending"
+	EloChange   float64            `bson:"eloChange" json:"eloChange"`
 	Messages    []Message          `bson:"messages" json:"messages"`
-	Transcripts map[string]string  `bson:"transcripts,omitempty" json:"transcripts,omitempty"` // For user vs user debates
+	Transcripts map[string]string  `bson:"transcripts,omitempty" json:"transcripts,omitempty"`
 	CreatedAt   time.Time          `bson:"createdAt" json:"createdAt"`
 	UpdatedAt   time.Time          `bson:"updatedAt" json:"updatedAt"`
 }
+
 
 func (s SavedDebateTranscript) MarshalJSON() ([]byte, error) {
 	type Alias SavedDebateTranscript

--- a/backend/services/transcriptservice.go
+++ b/backend/services/transcriptservice.go
@@ -186,6 +186,7 @@ func SubmitTranscripts(
 					resultFor,
 					[]models.Message{}, // You might want to reconstruct messages from transcripts
 					forSubmission.Transcripts,
+					forRecord.RatingChange
 				)
 				if err != nil {
 				}
@@ -659,7 +660,7 @@ func buildFallbackJudgeResult(merged map[string]string) string {
 }
 
 // SaveDebateTranscript saves a debate transcript for later viewing
-func SaveDebateTranscript(userID primitive.ObjectID, email, debateType, topic, opponent, result string, messages []models.Message, transcripts map[string]string) error {
+func SaveDebateTranscript(userID primitive.ObjectID, email, debateType, topic, opponent, result string, messages []models.Message, transcripts map[string]string, eloChange float64) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -682,11 +683,13 @@ func SaveDebateTranscript(userID primitive.ObjectID, email, debateType, topic, o
 
 		// If the result has changed or is "pending", update the transcript
 		if existingTranscript.Result != result || existingTranscript.Result == "pending" {
+
 			update := bson.M{
 				"$set": bson.M{
 					"result":      result,
 					"messages":    messages,
 					"transcripts": transcripts,
+					"eloChange":   eloChange,
 					"updatedAt":   time.Now(),
 				},
 			}
@@ -712,6 +715,7 @@ func SaveDebateTranscript(userID primitive.ObjectID, email, debateType, topic, o
 		Opponent:    opponent,
 		Result:      result,
 		Messages:    messages,
+		EloChange:   eloChange, 
 		Transcripts: transcripts,
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),

--- a/backend/services/transcriptservice.go
+++ b/backend/services/transcriptservice.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"log"
 
 	"arguehub/db"
 	"arguehub/models"
@@ -178,32 +179,36 @@ func SubmitTranscripts(
 
 				// Save transcript for "for" user
 				err = SaveDebateTranscript(
-					forUser.ID,
-					forUser.Email,
-					"user_vs_user",
-					topic,
-					againstUser.Email,
-					resultFor,
-					[]models.Message{}, // You might want to reconstruct messages from transcripts
-					forSubmission.Transcripts,
-					forRecord.RatingChange
-				)
-				if err != nil {
-				}
+				forUser.ID,
+				forUser.Email,
+				"user_vs_user",
+				topic,
+				againstUser.Email,
+				resultFor,
+				[]models.Message{},
+				forSubmission.Transcripts,
+				0.0,
+			)
+			if err != nil {
+				log.Println("Error saving transcript for user:", err)
+			}
 
-				// Save transcript for "against" user
-				err = SaveDebateTranscript(
-					againstUser.ID,
-					againstUser.Email,
-					"user_vs_user",
-					topic,
-					forUser.Email,
-					resultAgainst,
-					[]models.Message{}, // You might want to reconstruct messages from transcripts
-					againstSubmission.Transcripts,
-				)
-				if err != nil {
-				}
+			// Save transcript for "against" user
+			err = SaveDebateTranscript(
+				againstUser.ID,
+				againstUser.Email,
+				"user_vs_user",
+				topic,
+				forUser.Email,
+				resultAgainst,
+				[]models.Message{},
+				againstSubmission.Transcripts,
+				0.0,
+			)
+			if err != nil {
+				log.Println("Error saving transcript for opponent:", err)
+			}
+
 
 				// Update ratings based on the result
 				outcomeFor := 0.5

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,6 +29,7 @@
         "date-fns": "^4.1.0",
         "fuse.js": "^7.1.0",
         "jotai": "^2.13.1",
+        "json5": "^2.2.3",
         "lucide-react": "^0.446.0",
         "react": "^18.3.1",
         "react-avatar": "^5.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "date-fns": "^4.1.0",
     "fuse.js": "^7.1.0",
     "jotai": "^2.13.1",
+    "json5": "^2.2.3",
     "lucide-react": "^0.446.0",
     "react": "^18.3.1",
     "react-avatar": "^5.0.4",
@@ -49,7 +50,7 @@
     "tailwind-scrollbar-hide": "^2.0.0",
     "tailwindcss-animate": "^1.0.7"
   },
-"devDependencies": {
+  "devDependencies": {
     "@aws-amplify/backend": "^1.4.0",
     "@aws-amplify/backend-cli": "^1.2.9",
     "@eslint/js": "^9.9.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,57 +50,59 @@ function AppRoutes() {
   }
   const { isAuthenticated } = authContext;
   return (
-    <Routes>
-      {/* Public routes */}
-      <Route
-        path='/'
-        element={
-          isAuthenticated ? <Navigate to='/startDebate' replace /> : <Home />
-        }
-      />
-      <Route path='/auth' element={<Authentication />} />
-      <Route path='/admin/login' element={<AdminSignup />} />
-      <Route path='/admin/dashboard' element={<AdminDashboard />} />
-      {/* Protected routes with layout */}
-      <Route element={<ProtectedRoute />}>
-        <Route path='/' element={<Layout />}>
-          <Route path='startDebate' element={<StartDebate />} />
-          <Route path='leaderboard' element={<Leaderboard />} />
-          <Route path='profile' element={<Profile />} />
-          <Route path='community' element={<CommunityFeed />} />
-          <Route path='about' element={<About />} />
-          <Route path='team-builder' element={<TeamBuilder />} />
-          <Route path='game/:userId' element={<DebateApp />} />
-          <Route path='bot-selection' element={<BotSelection />} />
-          <Route path='/tournaments' element={<TournamentHub />} />
-          <Route path='/coach' element={<CoachPage />} />
-          <Route
-            path='/tournament/:id/bracket'
-            element={<TournamentDetails />}
-          />
-          <Route
-            path='coach/strengthen-argument'
-            element={<StrengthenArgument />}
-          />
-          <Route path='/coach' element={<CoachPage />} />
-          <Route
-            path='coach/strengthen-argument'
-            element={<StrengthenArgument />}
-          />{' '}
-          {/* Add this route */}
-          <Route path='coach/pros-cons' element={<ProsConsChallenge />} />
+      <Routes>
+        {/* Public routes */}
+        <Route
+          path="/"
+          element={
+            isAuthenticated ? <Navigate to="/startDebate" replace /> : <Home />
+          }
+        />
+        <Route path="/auth" element={<Authentication />} />
+        <Route path="/admin/login" element={<AdminSignup />} />
+        <Route path="/admin/dashboard" element={<AdminDashboard />} />
+
+        {/* Protected routes */}
+        <Route element={<ProtectedRoute />}>
+          <Route element={<Layout />}>
+            <Route path="startDebate" element={<StartDebate />} />
+            <Route path="leaderboard" element={<Leaderboard />} />
+            <Route path="profile" element={<Profile />} />
+            <Route path="community" element={<CommunityFeed />} />
+            <Route path="about" element={<About />} />
+            <Route path="team-builder" element={<TeamBuilder />} />
+            <Route path="game/:userId" element={<DebateApp />} />
+            <Route path="bot-selection" element={<BotSelection />} />
+            <Route path="tournaments" element={<TournamentHub />} />
+            <Route
+              path="tournament/:id/bracket"
+              element={<TournamentDetails />}
+            />
+
+            {/* Coach routes */}
+            <Route path="coach" element={<CoachPage />}>
+              <Route
+                path="strengthen-argument"
+                element={<StrengthenArgument />}
+              />
+              <Route path="pros-cons" element={<ProsConsChallenge />} />
+            </Route>
+          </Route>
+
+          {/* Debate routes (outside layout) */}
+          <Route path="debate/:roomId" element={<DebateRoom />} />
+          <Route path="debate-room/:roomId" element={<OnlineDebateRoom />} />
+          <Route path="team-debate/:debateId" element={<TeamDebateRoom />} />
+          <Route path="spectator/:roomId" element={<ChatRoom />} />
+          <Route path="debate/:debateID/view" element={<ViewDebate />} />
+          <Route path="view-debate/:debateID" element={<ViewDebate />} />
+          <Route path="speech-test" element={<SpeechTest />} />
         </Route>
-        <Route path='/debate/:roomId' element={<DebateRoom />} />
-        <Route path='/debate-room/:roomId' element={<OnlineDebateRoom />} />
-        <Route path='/team-debate/:debateId' element={<TeamDebateRoom />} />
-        <Route path='/spectator/:roomId' element={<ChatRoom />} />
-        <Route path='/debate/:debateID/view' element={<ViewDebate />} />
-        <Route path='/view-debate/:debateID' element={<ViewDebate />} />
-        <Route path='/speech-test' element={<SpeechTest />} />
-      </Route>
-      {/* Redirect unknown routes */}
-      <Route path='*' element={<Navigate to='/' replace />} />
-    </Routes>
+
+        {/* Redirect unknown routes */}
+        <Route path="*" element={<Navigate to="/" replace />} />
+  </Routes>
+
   );
 }
 

--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -220,7 +220,6 @@ const DebateRoom: React.FC = () => {
   const judgingRef = useRef(false);
   const navigate = useNavigate();
   const location = useLocation();
-  const navigate = useNavigate();
   const debateData = location.state as DebateProps;
   const phases = debateData.phaseTimings;
   const debateKey = `debate_${debateData.userId}_${debateData.topic}_${debateData.debateId}`;

--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -702,9 +702,12 @@ const DebateRoom: React.FC = () => {
   const currentTurnType = turnTypes[state.currentPhase][state.phaseStep];
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-200 p-4">
+    <div className="min-h-screen p-4 bg-gradient-to-br from-gray-50 to-gray-200
+  dark:from-zinc-900 dark:to-zinc-800">
       <div className="w-full max-w-5xl mx-auto py-2">
-        <div className="bg-gradient-to-r from-orange-100 via-white to-orange-100 rounded-xl p-4 text-center transition-all duration-300 hover:shadow-lg">
+       <div className="rounded-xl p-4 text-center transition-all duration-300 hover:shadow-lg bg-gradient-to-r from-orange-100 via-white to-orange-100
+    dark:from-zinc-800 dark:via-zinc-900 dark:to-zinc-800
+       ">
           <h1 className="text-3xl font-bold text-gray-900 tracking-tight">
             Debate: {debateData.topic}
           </h1>
@@ -728,7 +731,7 @@ const DebateRoom: React.FC = () => {
 
       {popup.show && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
-          <div className="bg-white rounded-xl shadow-2xl p-6 max-w-md w-full transform transition-all duration-300 scale-105 border border-orange-200">
+         <div className="bg-white dark:bg-zinc-900 rounded-xl p-6 max-w-m w-full transform transition-all duration-300 scale-105 shadow-2xl border border-orange-200 dark:border-orange-400/30">
             {popup.isJudging ? (
               <div className="flex flex-col items-center">
                 <div className="animate-spin rounded-full h-16 w-16 border-t-4 border-blue500 mb-4"></div>
@@ -768,11 +771,7 @@ const DebateRoom: React.FC = () => {
 
       <div className="w-full max-w-5xl mx-auto flex flex-col md:flex-row gap-3">
         {/* Bot Section */}
-        <div
-          className={`relative w-full md:w-1/2 ${
-            state.isBotTurn ? "animate-glow" : ""
-          } bg-white border border-gray-200 shadow-md h-[540px] flex flex-col`}
-        >
+        <div className={`relative w-full md:w-1/2 ${state.isBotTurn ? "animate-glow" : ""} h-[540px] flex flex-col shadow-md bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-700`}>
           <div className="p-2 bg-gray-50 flex items-center gap-2">
             <div className="w-12 h-12 flex-shrink-0">
               <img
@@ -922,7 +921,7 @@ const DebateRoom: React.FC = () => {
             box-shadow: 0 0 5px rgba(255, 149, 0, 0.5);
           }
           50% {
-            box-shadow: 0 0 20px rgba(255, 149, 0, 0.8);
+            box-shadow: 0 0 20px rgba(255, 180, 80, 0.9);
           }
           100% {
             box-shadow: 0 0 5px rgba(255, 149, 0, 0.5);

--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -10,9 +10,6 @@ import { userAtom } from "@/state/userAtom";
 import { useNavigate } from "react-router-dom";
 
 
-const judgingRef = useRef(false);
-const navigate = useNavigate();
-
 // Bot type definition (same as in BotSelection)
 interface Bot {
   name: string;
@@ -222,6 +219,8 @@ const extractJSON = (response: string): string => {
 };
 
 const DebateRoom: React.FC = () => {
+  const judgingRef = useRef(false);
+  const navigate = useNavigate();
   const location = useLocation();
   const navigate = useNavigate();
   const debateData = location.state as DebateProps;

--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -7,6 +7,7 @@ import JudgmentPopup from "@/components/JudgementPopup";
 import { Mic, MicOff } from "lucide-react";
 import { useAtom } from "jotai";
 import { userAtom } from "@/state/userAtom";
+import JSON5 from "json5";
 
 // Bot type definition (same as in BotSelection)
 interface Bot {
@@ -597,16 +598,9 @@ const DebateRoom: React.FC = () => {
 
       let judgment: JudgmentData;
       try {
-        judgment = JSON.parse(jsonString);
-      } catch (parseError) {
-        console.error("JSON parse error:", parseError, "Trying to fix JSON...");
-        const fixedJson = jsonString
-          .replace(/'/g, '"')
-          .replace(/(\w+):/g, '"$1":')
-          .replace(/,\s*}/g, '}')
-          .replace(/,\s*]/g, ']');
-
-        judgment = JSON.parse(fixedJson);
+        judgment = JSON5.parse(jsonString);
+      }catch (e) {
+        throw new Error(`Failed to parse judgment JSON: ${e}`);
       }
 
       console.log("Parsed judgment:", judgment);

--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -7,8 +7,6 @@ import JudgmentPopup from "@/components/JudgementPopup";
 import { Mic, MicOff } from "lucide-react";
 import { useAtom } from "jotai";
 import { userAtom } from "@/state/userAtom";
-import { useNavigate } from "react-router-dom";
-
 
 // Bot type definition (same as in BotSelection)
 interface Bot {

--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -758,7 +758,7 @@ const DebateRoom: React.FC = () => {
           botDesc={bot.desc}
           onClose={() => {
             setShowJudgment(false);
-            navigate("/"); 
+            navigate("/startDebate"); 
           }}
         />
       )}

--- a/frontend/src/Pages/TeamDebateRoom.tsx
+++ b/frontend/src/Pages/TeamDebateRoom.tsx
@@ -1314,7 +1314,7 @@ const TeamDebateRoom: React.FC = () => {
               if (recognitionRef.current) {
                 try {
                   recognitionRef.current.start();
-      } catch (error) {
+              } catch (error) {
                   console.error("Error restarting speech recognition:", error);
                 }
               }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -57,21 +57,26 @@ function Header() {
 
   return (
     <>
-      <header className="flex items-center justify-between h-16 px-4 border-b border-gray-200">
-        <div className="text-lg font-semibold">{getBreadcrumbs()}</div>
+      <header className="flex items-center justify-between h-16 px-4 border-b border-border bg-background">
+        <div className="text-lg font-semibold text-foreground">
+          {getBreadcrumbs()}
+        </div>
+
         <div className="flex items-center gap-4">
           <button className="relative">
-            <Bell className="w-5 h-5 text-gray-600" />
-            <span className="absolute -top-1 -right-1 block h-2 w-2 rounded-full bg-red-500" />
+            <Bell className="w-5 h-5 text-muted-foreground" />
+            <span className="absolute -top-1 -right-1 block h-2 w-2 rounded-full bg-destructive" />
           </button>
+
           <img
             src={avatarImage}
             alt="User avatar"
-            className="w-8 h-8 rounded-full border-2 border-gray-300 object-cover"
+            className="w-8 h-8 rounded-full border-2 border-border object-cover"
           />
+
           <button
             onClick={toggleDrawer}
-            className="md:hidden p-2 rounded-md text-gray-600 hover:bg-gray-100"
+            className="md:hidden p-2 rounded-md text-muted-foreground hover:bg-muted"
             aria-label="Open menu"
           >
             <Menu className="h-6 w-6" />
@@ -82,13 +87,14 @@ function Header() {
       {isDrawerOpen && (
         <div className="fixed inset-0 z-[1000] md:hidden">
           <div
-            className="absolute inset-0 bg-black bg-opacity-50"
+            className="absolute inset-0 bg-black/50"
             onClick={toggleDrawer}
-          ></div>
-          <div className="relative w-64 h-full bg-white shadow-lg transform transition-transform duration-300 ease-in-out translate-x-0 ml-auto">
-            <div className="flex items-center justify-between h-16 px-4 border-b border-gray-200">
+          />
+
+          <div className="relative w-64 h-full bg-background border-l border-border shadow-lg ml-auto">
+            <div className="flex items-center justify-between h-16 px-4 border-b border-border">
               <div className="flex items-center gap-2">
-                <span className="text-xl font-bold text-gray-900">
+                <span className="text-xl font-bold text-foreground">
                   DebateAI by
                 </span>
                 <img
@@ -97,14 +103,16 @@ function Header() {
                   className="h-8 w-auto object-contain"
                 />
               </div>
+
               <button
                 onClick={toggleDrawer}
-                className="p-2 text-gray-600 hover:text-gray-900"
+                className="p-2 text-muted-foreground hover:text-foreground"
                 aria-label="Close menu"
               >
                 <X className="h-6 w-6" />
               </button>
             </div>
+
             <nav className="flex-1 px-2 py-4 space-y-2">
               <NavItem
                 to="/startDebate"
@@ -153,8 +161,8 @@ function NavItem({ to, label, icon, onClick }: NavItemProps) {
       className={({ isActive }) =>
         `group flex items-center px-2 py-2 text-sm font-medium rounded-md ${
           isActive
-            ? "bg-gray-200 text-gray-900"
-            : "text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+            ? "bg-muted text-foreground"
+            : "text-muted-foreground hover:bg-muted hover:text-foreground"
         }`
       }
     >
@@ -163,5 +171,6 @@ function NavItem({ to, label, icon, onClick }: NavItemProps) {
     </NavLink>
   );
 }
+
 
 export default Header;

--- a/frontend/src/components/JudgementPopup.tsx
+++ b/frontend/src/components/JudgementPopup.tsx
@@ -113,6 +113,7 @@ const JudgmentPopup: React.FC<JudgmentPopupProps> = ({
   botName,
   userStance,
   botStance,
+  botDesc,       
   forRole,
   againstRole,
   localRole = null,

--- a/frontend/src/components/Matchmaking.tsx
+++ b/frontend/src/components/Matchmaking.tsx
@@ -24,6 +24,8 @@ interface MatchmakingMessage {
   error?: string;
 }
 
+
+
 const Matchmaking: React.FC = () => {
   const [pool, setPool] = useState<MatchmakingPool[]>([]);
   const [isConnected, setIsConnected] = useState(false);
@@ -32,6 +34,13 @@ const Matchmaking: React.FC = () => {
   const { user, isLoading } = useUser();
   const wsRef = useRef<WebSocket | null>(null);
   const navigate = useNavigate();
+
+    // Reset matchmaking UI state on page refresh
+    useEffect(() => {
+      setIsInPool(false);
+      setWaitTime(0);
+    }, []);
+
 
   useEffect(() => {
     // If still loading, wait

--- a/frontend/src/components/Matchmaking.tsx
+++ b/frontend/src/components/Matchmaking.tsx
@@ -35,13 +35,6 @@ const Matchmaking: React.FC = () => {
   const wsRef = useRef<WebSocket | null>(null);
   const navigate = useNavigate();
 
-    // Reset matchmaking UI state on page refresh
-    useEffect(() => {
-      setIsInPool(false);
-      setWaitTime(0);
-    }, []);
-
-
   useEffect(() => {
     // If still loading, wait
     if (isLoading) {

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -115,7 +115,12 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none",
+      "text-foreground",
+      "data-[highlighted]:bg-muted data-[highlighted]:text-foreground",
+      "high-contrast:data-[highlighted]:bg-[hsl(var(--hc-hover-bg))]",
+      "high-contrast:data-[highlighted]:text-[hsl(var(--hc-hover-text))]",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}
@@ -125,10 +130,12 @@ const SelectItem = React.forwardRef<
         <CheckIcon className="h-4 w-4" />
       </SelectPrimitive.ItemIndicator>
     </span>
+
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
 ))
 SelectItem.displayName = SelectPrimitive.Item.displayName
+
 
 const SelectSeparator = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Separator>,

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -131,10 +131,13 @@ const SelectItem = React.forwardRef<
       </SelectPrimitive.ItemIndicator>
     </span>
 
-    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    <SelectPrimitive.ItemText>
+      {children}
+    </SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
 ))
 SelectItem.displayName = SelectPrimitive.Item.displayName
+
 
 
 const SelectSeparator = React.forwardRef<

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -85,6 +85,10 @@
     --chart-5: 180 100% 50%;
   }
 }
+.high-contrast {
+  --hc-hover-bg: 48 100% 50%;      
+  --hc-hover-text: 0 0% 0%;       
+}
 
 @layer base {
   * {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -85,9 +85,12 @@
     --chart-5: 180 100% 50%;
   }
 }
-.high-contrast {
-  --hc-hover-bg: 48 100% 50%;      
-  --hc-hover-text: 0 0% 0%;       
+
+@layer base {
+  .high-contrast {
+    --hc-hover-bg: 48 100% 50%;
+    --hc-hover-text: 0 0% 0%;
+  }
 }
 
 @layer base {

--- a/frontend/src/utils/speechTest.ts
+++ b/frontend/src/utils/speechTest.ts
@@ -29,13 +29,13 @@ export class SpeechRecognitionTest {
     this.recognition.lang = "en-US";
     this.recognition.maxAlternatives = 1;
 
-    // START EVENT
+    // START
     this.recognition.onstart = () => {
       this.isListening = true;
       console.log("Speech recognition started");
     };
 
-    // RESULT EVENT
+    // RESULTS
     this.recognition.onresult = (event: SpeechRecognitionEvent) => {
       let interimTranscript = "";
       let finalTranscript = "";
@@ -44,20 +44,12 @@ export class SpeechRecognitionTest {
         const result = event.results[i];
         const transcript = result[0].transcript;
 
-        if (result.isFinal) {
-          finalTranscript += transcript + " ";
-        } else {
-          interimTranscript += transcript;
-        }
+        if (result.isFinal) finalTranscript += transcript + " ";
+        else interimTranscript += transcript;
       }
 
-      if (finalTranscript) {
-        console.log("✅ Final:", finalTranscript.trim());
-      }
-
-      if (interimTranscript) {
-        console.log("⌛ Interim:", interimTranscript);
-      }
+      if (finalTranscript) console.log("✅ Final:", finalTranscript.trim());
+      if (interimTranscript) console.log("⌛ Interim:", interimTranscript);
     };
 
     // SAFE AUTO RESTART
@@ -67,70 +59,78 @@ export class SpeechRecognitionTest {
 
       if (!this.shouldRestart) return;
 
-      console.log("Restarting recognition...");
-
       this.restartTimeout = window.setTimeout(() => {
-        this.restartTimeout = null;
-
-        if (!this.shouldRestart || this.isListening) return;
+        if (!this.shouldRestart) return;
 
         try {
           this.recognition?.start();
         } catch (error) {
           console.error("Restart failed:", error);
+          this.shouldRestart = false;
+          this.restartTimeout = null;
         }
       }, 500);
     };
 
     // ERROR HANDLING
-    this.recognition.onerror = (event: any) => {
+    this.recognition.onerror = (ev: Event) => {
+      const event = ev as SpeechRecognitionErrorEvent;
+
       console.error("Speech error:", event.error, event.message);
 
-      // stop restart loop on fatal errors
+      // stop restart only on real fatal errors
       if (
         event.error === "not-allowed" ||
         event.error === "service-not-allowed" ||
-        event.error === "audio-capture" ||
-        event.error === "aborted"
+        event.error === "audio-capture"
       ) {
         this.shouldRestart = false;
       }
     };
   }
 
-  // START LISTENING
+  // ===============================
+  // START LISTENING (RACE SAFE)
+  // ===============================
   public async start(): Promise<boolean> {
     if (!this.supported || !this.recognition || this.isListening) {
       return false;
     }
 
+    // 👇 mark start intent FIRST
+    this.shouldRestart = true;
+
     const allowed = await this.checkMicrophonePermission();
-    if (!allowed) {
-      console.warn("Microphone permission denied");
+
+    // 👇 stop() may have been called while waiting
+    if (!this.shouldRestart) {
+      console.log("Start cancelled during permission request");
       return false;
     }
 
-    this.shouldRestart = true;
+    if (!allowed) {
+      console.warn("Microphone permission denied");
+      this.shouldRestart = false;
+      return false;
+    }
 
     try {
       this.recognition.start();
       return true;
     } catch (error) {
       console.error("Start failed:", error);
-
-      // IMPORTANT: prevent unwanted restart
       this.shouldRestart = false;
       this.isListening = false;
-
       return false;
     }
   }
 
-  // STOP LISTENING
+  // ===============================
+  // STOP LISTENING (FULL CANCEL)
+  // ===============================
   public stop() {
     this.shouldRestart = false;
 
-    // cancel pending restart
     if (this.restartTimeout !== null) {
       clearTimeout(this.restartTimeout);
       this.restartTimeout = null;
@@ -149,7 +149,6 @@ export class SpeechRecognitionTest {
     return this.supported;
   }
 
-  // CHECK MICROPHONE PERMISSION
   public async checkMicrophonePermission(): Promise<boolean> {
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
@@ -161,7 +160,9 @@ export class SpeechRecognitionTest {
   }
 }
 
+// ===============================
 // TEST HELPER
+// ===============================
 export const testSpeechRecognition = async () => {
   const test = new SpeechRecognitionTest();
 
@@ -173,7 +174,6 @@ export const testSpeechRecognition = async () => {
   const started = await test.start();
   if (!started) return;
 
-  // stop after 10 seconds
   setTimeout(() => {
     test.stop();
     console.log("⏹ Manually stopped");

--- a/frontend/src/utils/speechTest.ts
+++ b/frontend/src/utils/speechTest.ts
@@ -1,6 +1,8 @@
 export class SpeechRecognitionTest {
   private recognition: SpeechRecognition | null = null;
   private supported: boolean;
+  private shouldRestart = false;
+  private isListening = false;
 
   constructor() {
     this.supported =
@@ -8,12 +10,12 @@ export class SpeechRecognitionTest {
 
     if (this.supported) {
       const SpeechRecognitionCtor =
-        window.SpeechRecognition || window.webkitSpeechRecognition;
+        (window as any).SpeechRecognition ||
+        (window as any).webkitSpeechRecognition;
 
       if (SpeechRecognitionCtor) {
         this.recognition = new SpeechRecognitionCtor();
         this.setupRecognition();
-      } else {
       }
     }
   }
@@ -26,9 +28,13 @@ export class SpeechRecognitionTest {
     this.recognition.lang = 'en-US';
     this.recognition.maxAlternatives = 1;
 
+    // START
     this.recognition.onstart = () => {
+      this.isListening = true;
+      console.log("Speech recognition started");
     };
 
+    // RESULTS
     this.recognition.onresult = (event: SpeechRecognitionEvent) => {
       let interimTranscript = '';
       let finalTranscript = '';
@@ -45,40 +51,71 @@ export class SpeechRecognitionTest {
       }
 
       if (finalTranscript) {
+        console.log("✅ Final:", finalTranscript.trim());
       }
+
       if (interimTranscript) {
+        console.log("⌛ Interim:", interimTranscript);
       }
     };
 
+    // AUTO RESTART WHEN STOPPED
     this.recognition.onend = () => {
+      this.isListening = false;
+      console.log("Speech recognition ended");
+
+      if (this.shouldRestart) {
+        console.log("🔁 Restarting recognition...");
+        setTimeout(() => {
+          try {
+            this.recognition?.start();
+          } catch {}
+        }, 500);
+      }
     };
 
-    // ✅ Fix typing issue with type assertion
-    this.recognition.onerror = (event: Event) => {
-      const err = event as unknown as SpeechRecognitionErrorEvent;
-      console.error('Speech recognition error', err.error, err.message);
+    // ERROR HANDLING
+    this.recognition.onerror = (event: any) => {
+      console.error("Speech error:", event.error, event.message);
+
+      // stop infinite restart loop if permission denied
+      if (event.error === "not-allowed" || event.error === "service-not-allowed") {
+        this.shouldRestart = false;
+      }
     };
   }
 
-  public start(): boolean {
-    if (!this.supported || !this.recognition) {
+  // START LISTENING
+  public async start(): Promise<boolean> {
+    if (!this.supported || !this.recognition || this.isListening) {
       return false;
     }
+
+    const allowed = await this.checkMicrophonePermission();
+    if (!allowed) {
+      console.warn("Microphone permission denied");
+      return false;
+    }
+
+    this.shouldRestart = true;
 
     try {
       this.recognition.start();
       return true;
     } catch (error) {
+      console.error("Start failed:", error);
       return false;
     }
   }
 
+  // STOP LISTENING
   public stop() {
-    if (this.recognition) {
+    this.shouldRestart = false;
+
+    if (this.recognition && this.isListening) {
       try {
         this.recognition.stop();
-      } catch (error) {
-      }
+      } catch {}
     }
   }
 
@@ -86,29 +123,34 @@ export class SpeechRecognitionTest {
     return this.supported;
   }
 
+  // CHECK MIC PERMISSION
   public async checkMicrophonePermission(): Promise<boolean> {
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      stream.getTracks().forEach((track) => track.stop());
+      stream.getTracks().forEach(track => track.stop());
       return true;
-    } catch (error) {
+    } catch {
       return false;
     }
   }
 }
 
-// Export a simple test function
-export const testSpeechRecognition = () => {
+// TEST FUNCTION
+export const testSpeechRecognition = async () => {
   const test = new SpeechRecognitionTest();
 
   if (!test.isSpeechRecognitionSupported()) {
+    console.log("Speech recognition not supported");
     return;
   }
 
-  test.start();
+  const started = await test.start();
 
-  // Stop after 10 seconds
+  if (!started) return;
+
+  // stop after 10 seconds
   setTimeout(() => {
     test.stop();
+    console.log("Manually stopped");
   }, 10000);
 };

--- a/frontend/src/utils/speechTest.ts
+++ b/frontend/src/utils/speechTest.ts
@@ -91,38 +91,43 @@ export class SpeechRecognitionTest {
 
   // START LISTENING (RACE SAFE)
   public async start(): Promise<boolean> {
-    if (!this.supported || !this.recognition || this.isListening) {
-      return false;
-    }
-
-    // mark start intent FIRST
-    this.shouldRestart = true;
-
-    const allowed = await this.checkMicrophonePermission();
-
-    // stop() may have been called while waiting
-    if (!this.shouldRestart) {
-      console.log("Start cancelled during permission request");
-      return false;
-    }
-
-    if (!allowed) {
-      console.warn("Microphone permission denied");
-      this.shouldRestart = false;
-      return false;
-    }
-
-    try {
-      this.recognition.start();
-      return true;
-    } catch (error) {
-      console.error("Start failed:", error);
-      this.shouldRestart = false;
-      this.isListening = false;
-      return false;
-    }
+  if (!this.supported || !this.recognition || this.isListening) {
+    return false;
   }
-  // STOP LISTENING (FULL CANCEL)
+
+  //FIX: cancel any pending auto-restart
+  if (this.restartTimeout) {
+    clearTimeout(this.restartTimeout);
+    this.restartTimeout = null;
+  }
+
+  this.shouldRestart = true;
+
+  const allowed = await this.checkMicrophonePermission();
+
+  if (!this.shouldRestart) {
+    console.log("Start cancelled during permission request");
+    return false;
+  }
+
+  if (!allowed) {
+    console.warn("Microphone permission denied");
+    this.shouldRestart = false;
+    return false;
+  }
+
+  try {
+    this.recognition.start();
+    this.isListening = true;
+    return true;
+  } catch (error) {
+    console.error("Start failed:", error);
+    this.shouldRestart = false;
+    this.isListening = false;
+    return false;
+  }
+}
+
   public stop() {
     this.shouldRestart = false;
 

--- a/frontend/src/utils/speechTest.ts
+++ b/frontend/src/utils/speechTest.ts
@@ -48,8 +48,8 @@ export class SpeechRecognitionTest {
         else interimTranscript += transcript;
       }
 
-      if (finalTranscript) console.log("✅ Final:", finalTranscript.trim());
-      if (interimTranscript) console.log("⌛ Interim:", interimTranscript);
+      if (finalTranscript) console.log("Final:", finalTranscript.trim());
+      if (interimTranscript) console.log("Interim:", interimTranscript);
     };
 
     // SAFE AUTO RESTART
@@ -89,20 +89,18 @@ export class SpeechRecognitionTest {
     };
   }
 
-  // ===============================
   // START LISTENING (RACE SAFE)
-  // ===============================
   public async start(): Promise<boolean> {
     if (!this.supported || !this.recognition || this.isListening) {
       return false;
     }
 
-    // 👇 mark start intent FIRST
+    // mark start intent FIRST
     this.shouldRestart = true;
 
     const allowed = await this.checkMicrophonePermission();
 
-    // 👇 stop() may have been called while waiting
+    // stop() may have been called while waiting
     if (!this.shouldRestart) {
       console.log("Start cancelled during permission request");
       return false;
@@ -124,10 +122,7 @@ export class SpeechRecognitionTest {
       return false;
     }
   }
-
-  // ===============================
   // STOP LISTENING (FULL CANCEL)
-  // ===============================
   public stop() {
     this.shouldRestart = false;
 
@@ -160,9 +155,7 @@ export class SpeechRecognitionTest {
   }
 }
 
-// ===============================
 // TEST HELPER
-// ===============================
 export const testSpeechRecognition = async () => {
   const test = new SpeechRecognitionTest();
 
@@ -176,6 +169,6 @@ export const testSpeechRecognition = async () => {
 
   setTimeout(() => {
     test.stop();
-    console.log("⏹ Manually stopped");
+    console.log("Manually stopped");
   }, 10000);
 };

--- a/frontend/src/utils/speechTest.ts
+++ b/frontend/src/utils/speechTest.ts
@@ -3,10 +3,11 @@ export class SpeechRecognitionTest {
   private supported: boolean;
   private shouldRestart = false;
   private isListening = false;
+  private restartTimeout: number | null = null;
 
   constructor() {
     this.supported =
-      'SpeechRecognition' in window || 'webkitSpeechRecognition' in window;
+      "SpeechRecognition" in window || "webkitSpeechRecognition" in window;
 
     if (this.supported) {
       const SpeechRecognitionCtor =
@@ -25,26 +26,26 @@ export class SpeechRecognitionTest {
 
     this.recognition.continuous = true;
     this.recognition.interimResults = true;
-    this.recognition.lang = 'en-US';
+    this.recognition.lang = "en-US";
     this.recognition.maxAlternatives = 1;
 
-    // START
+    // START EVENT
     this.recognition.onstart = () => {
       this.isListening = true;
       console.log("Speech recognition started");
     };
 
-    // RESULTS
+    // RESULT EVENT
     this.recognition.onresult = (event: SpeechRecognitionEvent) => {
-      let interimTranscript = '';
-      let finalTranscript = '';
+      let interimTranscript = "";
+      let finalTranscript = "";
 
       for (let i = event.resultIndex; i < event.results.length; i++) {
         const result = event.results[i];
         const transcript = result[0].transcript;
 
         if (result.isFinal) {
-          finalTranscript += transcript + ' ';
+          finalTranscript += transcript + " ";
         } else {
           interimTranscript += transcript;
         }
@@ -59,27 +60,39 @@ export class SpeechRecognitionTest {
       }
     };
 
-    // AUTO RESTART WHEN STOPPED
+    // SAFE AUTO RESTART
     this.recognition.onend = () => {
       this.isListening = false;
       console.log("Speech recognition ended");
 
-      if (this.shouldRestart) {
-        console.log("🔁 Restarting recognition...");
-        setTimeout(() => {
-          try {
-            this.recognition?.start();
-          } catch {}
-        }, 500);
-      }
+      if (!this.shouldRestart) return;
+
+      console.log("Restarting recognition...");
+
+      this.restartTimeout = window.setTimeout(() => {
+        this.restartTimeout = null;
+
+        if (!this.shouldRestart || this.isListening) return;
+
+        try {
+          this.recognition?.start();
+        } catch (error) {
+          console.error("Restart failed:", error);
+        }
+      }, 500);
     };
 
     // ERROR HANDLING
     this.recognition.onerror = (event: any) => {
       console.error("Speech error:", event.error, event.message);
 
-      // stop infinite restart loop if permission denied
-      if (event.error === "not-allowed" || event.error === "service-not-allowed") {
+      // stop restart loop on fatal errors
+      if (
+        event.error === "not-allowed" ||
+        event.error === "service-not-allowed" ||
+        event.error === "audio-capture" ||
+        event.error === "aborted"
+      ) {
         this.shouldRestart = false;
       }
     };
@@ -104,6 +117,11 @@ export class SpeechRecognitionTest {
       return true;
     } catch (error) {
       console.error("Start failed:", error);
+
+      // IMPORTANT: prevent unwanted restart
+      this.shouldRestart = false;
+      this.isListening = false;
+
       return false;
     }
   }
@@ -112,10 +130,18 @@ export class SpeechRecognitionTest {
   public stop() {
     this.shouldRestart = false;
 
+    // cancel pending restart
+    if (this.restartTimeout !== null) {
+      clearTimeout(this.restartTimeout);
+      this.restartTimeout = null;
+    }
+
     if (this.recognition && this.isListening) {
       try {
         this.recognition.stop();
-      } catch {}
+      } catch (error) {
+        console.error("Stop failed:", error);
+      }
     }
   }
 
@@ -123,7 +149,7 @@ export class SpeechRecognitionTest {
     return this.supported;
   }
 
-  // CHECK MIC PERMISSION
+  // CHECK MICROPHONE PERMISSION
   public async checkMicrophonePermission(): Promise<boolean> {
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
@@ -135,22 +161,21 @@ export class SpeechRecognitionTest {
   }
 }
 
-// TEST FUNCTION
+// TEST HELPER
 export const testSpeechRecognition = async () => {
   const test = new SpeechRecognitionTest();
 
   if (!test.isSpeechRecognitionSupported()) {
-    console.log("Speech recognition not supported");
+    console.log("Speech recognition not supported in this browser");
     return;
   }
 
   const started = await test.start();
-
   if (!started) return;
 
   // stop after 10 seconds
   setTimeout(() => {
     test.stop();
-    console.log("Manually stopped");
+    console.log("⏹ Manually stopped");
   }, 10000);
 };

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -63,9 +63,7 @@ export default {
     require("tailwindcss-animate"),
     require("tailwind-scrollbar-hide"),
     function ({ addVariant }) {
-    addVariant('high-contrast', '@media (prefers-contrast: more)');
+      addVariant('high-contrast', '@media (prefers-contrast: more)');
     },
-    require("tailwindcss-animate"),
-    require("tailwind-scrollbar-hide"),
-  ],
+  ]
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -62,5 +62,10 @@ export default {
   plugins: [
     require("tailwindcss-animate"),
     require("tailwind-scrollbar-hide"),
+    function ({ addVariant }) {
+    addVariant('high-contrast', '@media (prefers-contrast: more)');
+    },
+    require("tailwindcss-animate"),
+    require("tailwind-scrollbar-hide"),
   ],
 }


### PR DESCRIPTION
When using the Web Speech API with recognition.continuous = true, speech recognition still stops automatically after a short period of silence or inactivity. This breaks the expected continuous listening behavior, as recognition should remain active until manually stopped by the application.

Steps to reproduce:
1. Initialize SpeechRecognition
2. Enable continuous mode
3. Start recognition
4. Wait for silence or inactivity
5.  Recognition stops automatically

Expected behavior:
Recognition should continue listening until manually stopped.

Actual behavior:
Recognition stops automatically due to silence, timeout, or internal browser reset.

Environment:
1. Browser: Chrome / Edge
2. Frontend: TypeScript web application
3. API: Web Speech API

Workaround:
Manually restarting recognition inside the onend event.

Impact:
Critical – breaks continuous listening functionality.

close #329 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Debate results now display actual Elo changes.
  * High-contrast accessibility variant added.

* **Improvements**
  * Dark mode styling refreshed across the app.
  * More robust judgment flow with clearer error messages and concurrency guard.
  * Speech recognition: permission checks, auto-restart safeguards, and async start/stop.
  * Header and navigation refreshed; routes reorganized for protected/coach/debate pages.
  * Judgment popup now accepts bot description text.

* **Chores**
  * Added JSON5 support for more flexible result parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->