### PR TITLE
Feat/Unified DebateAI branding, interactive AOSSIE discovery, and navigation polish

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import StrengthenArgument from './Pages/StrengthenArgument';
 import SpeechTest from './Pages/SpeechTest';
 // Layout
 import Layout from './components/Layout';
+import SupportOpenSource from './Pages/SupportOpenSource';
 import CoachPage from './Pages/CoachPage';
 import ChatRoom from './components/ChatRoom';
 import TournamentHub from './Pages/TournamentHub';
@@ -61,6 +62,12 @@ function AppRoutes() {
       <Route path='/auth' element={<Authentication />} />
       <Route path='/admin/login' element={<AdminSignup />} />
       <Route path='/admin/dashboard' element={<AdminDashboard />} />
+      {/* Public routes with layout */}
+      <Route element={<Layout />}>
+        <Route path='about' element={<About />} />
+        <Route path='support-debateai' element={<SupportOpenSource />} />
+      </Route>
+
       {/* Protected routes with layout */}
       <Route element={<ProtectedRoute />}>
         <Route path='/' element={<Layout />}>
@@ -68,7 +75,6 @@ function AppRoutes() {
           <Route path='leaderboard' element={<Leaderboard />} />
           <Route path='profile' element={<Profile />} />
           <Route path='community' element={<CommunityFeed />} />
-          <Route path='about' element={<About />} />
           <Route path='team-builder' element={<TeamBuilder />} />
           <Route path='game/:userId' element={<DebateApp />} />
           <Route path='bot-selection' element={<BotSelection />} />

--- a/frontend/src/Pages/About.tsx
+++ b/frontend/src/Pages/About.tsx
@@ -112,7 +112,7 @@ function About() {
 
       {/* Footer */}
       <footer className="text-center text-xs md:text-sm text-muted-foreground mt-8">
-        © 2016-2025 AOSSIE. All rights reserved.
+        © 2016-{new Date().getFullYear()} <a href="https://aossie.org" target="_blank" rel="noopener noreferrer" className="hover:text-primary transition-colors">AOSSIE</a>. All rights reserved.
       </footer>
     </div>
   );

--- a/frontend/src/Pages/CoachPage.tsx
+++ b/frontend/src/Pages/CoachPage.tsx
@@ -130,8 +130,11 @@ const CoachPage: React.FC = () => {
               Subscribe
             </Button>
           </div>
-          <p className="text-sm text-muted-foreground mt-4">
-            © 2025 ArgueHub. All rights reserved.
+          <p className="text-sm text-muted-foreground mt-4 italic font-medium">
+            Managed with ❤️ by <a href="https://aossie.org" target="_blank" rel="noopener noreferrer" className="hover:text-primary transition-colors">AOSSIE</a>
+          </p>
+          <p className="text-xs text-muted-foreground mt-1">
+            © {new Date().getFullYear()} DebateAI. All rights reserved.
           </p>
         </div>
       </footer>

--- a/frontend/src/Pages/Home.tsx
+++ b/frontend/src/Pages/Home.tsx
@@ -1,18 +1,15 @@
-import DebateCover from "../assets/DebateCover4.svg";
+import React, { useContext } from "react";
 import { Button } from "@/components/ui/button";
 import { useNavigate } from "react-router-dom";
+import { AuthContext } from "@/context/authContext";
+import DebateCover from "../assets/DebateCover4.svg";
 import { RiRobot2Fill } from "react-icons/ri";
 import { FaHandshakeSimpleSlash } from "react-icons/fa6";
-import { useContext } from "react";
-import { AuthContext } from "@/context/authContext";
-
-{/* TODO modify the home page for already logged in and signed up state  */}
+import AOSSIELogo from "@/assets/aossie.png";
 
 const Home: React.FC = () => {
   const navigate = useNavigate();
   const authContext = useContext(AuthContext);
-
-  
 
   const signupHandler = () => {
     navigate('/auth', { state: { isSignUp: true } });
@@ -21,6 +18,7 @@ const Home: React.FC = () => {
   const loginHandler = () => {
     navigate('/auth', { state: { isSignUp: false } });
   };
+
   const handlePlayDebateClick = () => {
     if (authContext?.isAuthenticated) {
       navigate('/game');  
@@ -31,7 +29,7 @@ const Home: React.FC = () => {
 
   const handlePlayBotClick = () => {
     if (authContext?.isAuthenticated) {
-      navigate('/game');  // Navigate to play page if authenticated
+      navigate('/bot-selection');  // Navigate to bot selection page
     } else {
       navigate('/auth', { state: { isSignUp: false } });  // Navigate to login page if not authenticated
     }
@@ -43,17 +41,44 @@ const Home: React.FC = () => {
   }
 
   return (
-    <div className="flex flex-col min-h-screen">
-      <nav className="flex items-center justify-between px-4 py-4 md:px-12">
-        <h1 className="text-xl md:text-3xl font-bold">Argue-Hub</h1>
-          {
-            authContext?.isAuthenticated?(<Button onClick={logoutHandler}>Log out</Button>):(
-              <div className="flex">
-                <Button className="mr-2" onClick={loginHandler}>Login</Button>
-                <Button variant="outline" onClick={signupHandler}>Sign Up</Button>
-              </div>  
-            )
-          }
+    <div className="flex flex-col min-h-screen bg-background">
+      <nav className="flex items-center justify-between px-6 py-4 border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+        <div className="flex items-center gap-4">
+          <a 
+            href="https://aossie.org" 
+            target="_blank" 
+            rel="noopener noreferrer"
+            className="p-1 hover:opacity-80 transition-opacity"
+          >
+            <img src={AOSSIELogo} alt="AOSSIE Logo" className="h-8 w-auto object-contain" />
+          </a>
+          <div className="flex flex-col">
+            <span className="text-2xl font-black tracking-tight text-primary leading-none">DebateAI</span>
+            <span className="text-[10px] text-muted-foreground uppercase tracking-widest font-bold">by AOSSIE</span>
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          {authContext?.isAuthenticated ? (
+            <Button onClick={logoutHandler} variant="destructive" size="sm">Log out</Button>
+          ) : (
+            <>
+              <Button 
+                variant="ghost" 
+                className="text-foreground hover:bg-accent"
+                onClick={loginHandler}
+              >
+                Login
+              </Button>
+              <Button 
+                variant="outline"
+                className="font-bold border-primary text-primary hover:bg-primary hover:text-primary-foreground"
+                onClick={signupHandler}
+              >
+                Sign Up
+              </Button>
+            </>
+          )}
+        </div>
       </nav>
 
       <div className="flex items-center justify-center">

--- a/frontend/src/Pages/StartDebate.tsx
+++ b/frontend/src/Pages/StartDebate.tsx
@@ -7,6 +7,7 @@ import DebateCover from "../assets/DebateCover4.svg";
 import { Button } from "../components/ui/button";
 import { AuthContext } from "../context/authContext";
 import DebatePopup from "@/components/DebatePopup";
+import AOSSIELogo from "@/assets/aossie.png";
 
 const StartDebate = () => {
   const navigate = useNavigate();
@@ -41,6 +42,19 @@ const StartDebate = () => {
             />
           </div>
           <div className="flex w-full md:w-1/3 flex-col items-center justify-center space-y-4 p-4">
+            <div className="flex flex-col items-center mb-6">
+              <a 
+                href="https://aossie.org" 
+                target="_blank" 
+                rel="noopener noreferrer"
+                className="mb-2 hover:opacity-80 transition-opacity"
+              >
+                <img src={AOSSIELogo} alt="AOSSIE Logo" className="h-12 w-auto object-contain" />
+              </a>
+              <div className="text-center">
+                <span className="text-sm text-muted-foreground uppercase tracking-[0.2em] font-black">by AOSSIE</span>
+              </div>
+            </div>
             <h3 className="text-xl md:text-4xl font-bold text-center">
               Play Debate Online on the <span className="text-primary">#1</span>{" "}
               Site!

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -23,6 +23,10 @@ import debateAiLogo from "@/assets/aossie.png";
 import avatarImage from "@/assets/avatar2.jpg";
 import { getNotifications, markNotificationAsRead, markAllNotificationsAsRead, deleteNotification, Notification } from "@/services/notificationService";
 
+/**
+ * Header component providing breadcrumb navigation, notifications, 
+ * and user profile management.
+ */
 function Header() {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const location = useLocation();
@@ -82,6 +86,10 @@ function Header() {
     setUnreadCount(0);
   };
 
+  /**
+   * Generates breadcrumb navigation based on the current URL path.
+   * @returns {JSX.Element} The breadcrumb component.
+   */
   const getBreadcrumbs = () => {
     const pathnames = location.pathname.split("/").filter((x) => x);
     return (
@@ -101,12 +109,20 @@ function Header() {
                 <BreadcrumbItem>
                   {isLast ? (
                     <BreadcrumbPage className="capitalize">
-                      {value.replace("-", " ")}
+                      {value === "support-debateai" 
+                        ? "Support DebateAI" 
+                        : value === "bot-selection" 
+                        ? "Bot Selection" 
+                        : value.replace("-", " ")}
                     </BreadcrumbPage>
                   ) : (
                     <BreadcrumbLink asChild>
                       <NavLink to={to} className="capitalize">
-                        {value.replace("-", " ")}
+                        {value === "support-debateai" 
+                          ? "Support DebateAI" 
+                          : value === "bot-selection" 
+                          ? "Bot Selection" 
+                          : value.replace("-", " ")}
                       </NavLink>
                     </BreadcrumbLink>
                   )}
@@ -282,7 +298,7 @@ function Header() {
             </div>
             <nav className="flex-1 px-2 py-4 space-y-2">
               <NavItem
-                to="/"
+                to="/startDebate"
                 label="Home"
                 icon={<Home className="mr-3 h-4 w-4" />}
                 onClick={toggleDrawer}
@@ -306,7 +322,7 @@ function Header() {
                 onClick={toggleDrawer}
               />
               <NavItem
-                to="/support-os"
+                to="/support-debateai"
                 label="Support DebateAI"
                 icon={<Heart className="mr-3 h-4 w-4 text-red-500 transition-all duration-300 group-hover:fill-red-500 group-hover:scale-110" />}
                 onClick={toggleDrawer}
@@ -326,6 +342,10 @@ interface NavItemProps {
   onClick?: () => void;
 }
 
+/**
+ * Individual navigation item for the mobile drawer.
+ * @param {NavItemProps} props - Component props.
+ */
 function NavItem({ to, label, icon, onClick }: NavItemProps) {
   return (
     <NavLink

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -142,7 +142,11 @@ function Header() {
         <div className="flex items-center gap-4">
           <Popover open={isNotificationsOpen} onOpenChange={setIsNotificationsOpen}>
             <PopoverTrigger asChild>
-              <button className="relative focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-full p-1 transition-colors">
+              <button
+                type="button"
+                aria-label="Open notifications"
+                className="relative focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-full p-1 transition-colors"
+              >
                 <Bell className="w-5 h-5 text-muted-foreground hover:text-foreground" />
                 {unreadCount > 0 && (
                   <span className="absolute top-1 right-1 block h-2 w-2 rounded-full bg-destructive" />
@@ -177,9 +181,11 @@ function Header() {
                         onClick={() => handleNotificationClick(notification)}
                       >
                         <button
+                          type="button"
                           onClick={(e) => handleDeleteNotification(e, notification.id)}
-                          className="absolute top-2 right-2 p-1 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 transition-opacity"
+                          className="absolute top-2 right-2 p-1 text-muted-foreground hover:text-destructive opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
                           title="Delete notification"
+                          aria-label="Delete notification"
                         >
                           <X className="w-3 h-3" />
                         </button>
@@ -207,7 +213,11 @@ function Header() {
           
           <Popover>
             <PopoverTrigger asChild>
-              <button className="focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-full transition-opacity">
+              <button
+                type="button"
+                aria-label="Open user menu"
+                className="focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-full transition-opacity"
+              >
                 <img
                   src={user?.avatarUrl || avatarImage}
                   alt="User avatar"

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -113,7 +113,7 @@ function Header() {
                         ? "Support DebateAI" 
                         : value === "bot-selection" 
                         ? "Bot Selection" 
-                        : value.replace("-", " ")}
+                        : value.replace(/-/g, " ")}
                     </BreadcrumbPage>
                   ) : (
                     <BreadcrumbLink asChild>
@@ -122,7 +122,7 @@ function Header() {
                           ? "Support DebateAI" 
                           : value === "bot-selection" 
                           ? "Bot Selection" 
-                          : value.replace("-", " ")}
+                          : value.replace(/-/g, " ")}
                       </NavLink>
                     </BreadcrumbLink>
                   )}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext, useEffect } from "react";
 import { NavLink, useLocation, useNavigate } from "react-router-dom";
-import { Bell, Menu, X, Home, BarChart, User, Info, LogOut, Check } from "lucide-react";
+import { Bell, Menu, X, Home, BarChart, User, Info, LogOut, Heart } from "lucide-react";
 import { useAtom } from "jotai";
 import { userAtom } from "@/state/userAtom";
 import { AuthContext } from "@/context/authContext";
@@ -121,26 +121,26 @@ function Header() {
 
   return (
     <>
-      <header className="flex items-center justify-between h-16 px-4 border-b border-gray-200">
+      <header className="flex items-center justify-between h-16 px-4 border-b border-border bg-background">
         <div className="text-lg font-semibold">{getBreadcrumbs()}</div>
         <div className="flex items-center gap-4">
           <Popover open={isNotificationsOpen} onOpenChange={setIsNotificationsOpen}>
             <PopoverTrigger asChild>
-              <button className="relative focus:outline-none">
-                <Bell className="w-5 h-5 text-gray-600" />
+              <button className="relative focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-full p-1 transition-colors">
+                <Bell className="w-5 h-5 text-muted-foreground hover:text-foreground" />
                 {unreadCount > 0 && (
-                  <span className="absolute -top-1 -right-1 block h-2 w-2 rounded-full bg-red-500" />
+                  <span className="absolute top-1 right-1 block h-2 w-2 rounded-full bg-destructive" />
                 )}
               </button>
             </PopoverTrigger>
-            <PopoverContent className="w-80 p-0" align="end">
-              <div className="flex items-center justify-between p-4 border-b border-gray-100">
-                <h4 className="font-semibold text-gray-900">Notifications</h4>
+            <PopoverContent className="w-80 p-0 bg-popover text-popover-foreground border-border" align="end">
+              <div className="flex items-center justify-between p-4 border-b border-border">
+                <h4 className="font-semibold">Notifications</h4>
                 {unreadCount > 0 && (
                   <Button 
                     variant="ghost" 
                     size="sm" 
-                    className="text-xs h-8 px-2 text-blue-600 hover:text-blue-800"
+                    className="text-xs h-8 px-2 text-primary hover:text-primary/80"
                     onClick={handleMarkAllRead}
                   >
                     Mark all read
@@ -149,34 +149,34 @@ function Header() {
               </div>
               <ScrollArea className="h-[300px]">
                 {notifications.length === 0 ? (
-                  <div className="p-8 text-center text-gray-500 text-sm">
+                  <div className="p-8 text-center text-muted-foreground text-sm">
                     No notifications yet
                   </div>
                 ) : (
-                  <div className="divide-y divide-gray-100">
+                  <div className="divide-y divide-border">
                     {notifications.map((notification) => (
                       <div 
                         key={notification.id}
-                        className={`p-4 hover:bg-gray-50 cursor-pointer transition-colors relative group ${!notification.isRead ? 'bg-blue-50/50' : ''}`}
+                        className={`p-4 hover:bg-accent cursor-pointer transition-colors relative group ${!notification.isRead ? 'bg-accent/50' : ''}`}
                         onClick={() => handleNotificationClick(notification)}
                       >
                         <button
                           onClick={(e) => handleDeleteNotification(e, notification.id)}
-                          className="absolute top-2 right-2 p-1 text-gray-400 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
+                          className="absolute top-2 right-2 p-1 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 transition-opacity"
                           title="Delete notification"
                         >
                           <X className="w-3 h-3" />
                         </button>
                         <div className="flex gap-3">
-                          <div className={`mt-1 h-2 w-2 rounded-full flex-shrink-0 ${!notification.isRead ? 'bg-blue-500' : 'bg-transparent'}`} />
+                          <div className={`mt-1 h-2 w-2 rounded-full flex-shrink-0 ${!notification.isRead ? 'bg-primary' : 'bg-transparent'}`} />
                           <div className="flex-1 space-y-1 pr-4">
-                            <p className="text-sm font-medium leading-none text-gray-900">
+                            <p className="text-sm font-medium leading-none">
                               {notification.title}
                             </p>
-                            <p className="text-sm text-gray-500 line-clamp-2">
+                            <p className="text-sm text-muted-foreground line-clamp-2">
                               {notification.message}
                             </p>
-                            <p className="text-xs text-gray-400">
+                            <p className="text-xs text-muted-foreground/60">
                               {new Date(notification.createdAt).toLocaleDateString()}
                             </p>
                           </div>
@@ -191,44 +191,44 @@ function Header() {
           
           <Popover>
             <PopoverTrigger asChild>
-              <button className="focus:outline-none">
+              <button className="focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-full transition-opacity">
                 <img
                   src={user?.avatarUrl || avatarImage}
                   alt="User avatar"
-                  className="w-8 h-8 rounded-full border-2 border-gray-300 object-cover cursor-pointer hover:opacity-80 transition-opacity"
+                  className="w-8 h-8 rounded-full border-2 border-border object-cover cursor-pointer hover:opacity-80 transition-opacity"
                 />
               </button>
             </PopoverTrigger>
-            <PopoverContent className="w-80 p-0" align="end">
-              <div className="p-4 border-b border-gray-100">
+            <PopoverContent className="w-80 p-0 bg-popover text-popover-foreground border-border" align="end">
+              <div className="p-4 border-b border-border">
                 <div className="flex items-center gap-3 mb-3">
                   <img
                     src={user?.avatarUrl || avatarImage}
                     alt="User avatar"
-                    className="w-12 h-12 rounded-full border-2 border-gray-200 object-cover"
+                    className="w-12 h-12 rounded-full border-2 border-border object-cover"
                   />
                   <div className="overflow-hidden">
-                    <h4 className="font-semibold text-gray-900 truncate">{user?.displayName || "User"}</h4>
-                    <p className="text-sm text-gray-500 truncate">{user?.email || "No email"}</p>
+                    <h4 className="font-semibold truncate">{user?.displayName || "User"}</h4>
+                    <p className="text-sm text-muted-foreground truncate">{user?.email || "No email"}</p>
                   </div>
                 </div>
                 <div className="space-y-2">
                   <div className="flex justify-between text-sm">
-                    <span className="text-gray-500">User ID</span>
-                    <span className="font-mono text-xs bg-gray-100 px-2 py-0.5 rounded text-gray-700 truncate max-w-[150px]" title={user?.id}>
+                    <span className="text-muted-foreground">User ID</span>
+                    <span className="font-mono text-xs bg-muted px-2 py-0.5 rounded text-muted-foreground truncate max-w-[150px]" title={user?.id}>
                       {user?.id || "N/A"}
                     </span>
                   </div>
                   <div className="flex justify-between text-sm">
-                    <span className="text-gray-500">Rating</span>
-                    <span className="font-medium text-blue-600">{user?.rating ? Math.round(user.rating) : 1500}</span>
+                    <span className="text-muted-foreground">Rating</span>
+                    <span className="font-medium text-primary">{user?.rating ? Math.round(user.rating) : 1500}</span>
                   </div>
                 </div>
               </div>
               <div className="p-2">
                 <button
                   onClick={() => auth?.logout()}
-                  className="w-full flex items-center gap-2 px-3 py-2 text-sm text-red-600 hover:bg-red-50 rounded-md transition-colors"
+                  className="w-full flex items-center gap-2 px-3 py-2 text-sm text-destructive hover:bg-destructive/10 rounded-md transition-colors"
                 >
                   <LogOut className="w-4 h-4" />
                   Sign out
@@ -236,10 +236,10 @@ function Header() {
               </div>
             </PopoverContent>
           </Popover>
-
+          
           <button
             onClick={toggleDrawer}
-            className="md:hidden p-2 rounded-md text-gray-600 hover:bg-gray-100"
+            className="md:hidden p-2 rounded-md text-muted-foreground hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring"
             aria-label="Open menu"
           >
             <Menu className="h-6 w-6" />
@@ -253,21 +253,28 @@ function Header() {
             className="absolute inset-0 bg-black bg-opacity-50"
             onClick={toggleDrawer}
           ></div>
-          <div className="relative w-64 h-full bg-white shadow-lg transform transition-transform duration-300 ease-in-out translate-x-0 ml-auto">
-            <div className="flex items-center justify-between h-16 px-4 border-b border-gray-200">
+          <div className="relative w-64 h-full bg-background border-l border-border shadow-lg transform transition-transform duration-300 ease-in-out translate-x-0 ml-auto">
+            <div className="flex items-center justify-between h-16 px-4 border-b border-border">
               <div className="flex items-center gap-2">
-                <span className="text-xl font-bold text-gray-900">
-                  DebateAI by
+                <span className="text-xl font-bold">
+                  DebateAI
                 </span>
-                <img
-                  src={debateAiLogo}
-                  alt="DebateAI Logo"
-                  className="h-8 w-auto object-contain"
-                />
+                <a 
+                  href="https://aossie.org" 
+                  target="_blank" 
+                  rel="noopener noreferrer"
+                  className="hover:opacity-80 transition-opacity"
+                >
+                  <img
+                    src={debateAiLogo}
+                    alt="DebateAI Logo"
+                    className="h-8 w-auto object-contain"
+                  />
+                </a>
               </div>
               <button
                 onClick={toggleDrawer}
-                className="p-2 text-gray-600 hover:text-gray-900"
+                className="p-2 text-muted-foreground hover:text-foreground"
                 aria-label="Close menu"
               >
                 <X className="h-6 w-6" />
@@ -275,7 +282,7 @@ function Header() {
             </div>
             <nav className="flex-1 px-2 py-4 space-y-2">
               <NavItem
-                to="/startDebate"
+                to="/"
                 label="Home"
                 icon={<Home className="mr-3 h-4 w-4" />}
                 onClick={toggleDrawer}
@@ -296,6 +303,12 @@ function Header() {
                 to="/about"
                 label="About"
                 icon={<Info className="mr-3 h-4 w-4" />}
+                onClick={toggleDrawer}
+              />
+              <NavItem
+                to="/support-os"
+                label="Support DebateAI"
+                icon={<Heart className="mr-3 h-4 w-4 text-red-500 transition-all duration-300 group-hover:fill-red-500 group-hover:scale-110" />}
                 onClick={toggleDrawer}
               />
             </nav>
@@ -319,10 +332,10 @@ function NavItem({ to, label, icon, onClick }: NavItemProps) {
       to={to}
       onClick={onClick}
       className={({ isActive }) =>
-        `group flex items-center px-2 py-2 text-sm font-medium rounded-md ${
+        `group flex items-center px-2 py-2 text-sm font-medium rounded-md transition-colors ${
           isActive
-            ? "bg-gray-200 text-gray-900"
-            : "text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+            ? "bg-primary/20 text-primary"
+            : "text-muted-foreground hover:bg-accent hover:text-foreground"
         }`
       }
     >


### PR DESCRIPTION
###  Addressed Issues:

Fixes #355 

###  Screenshots/Recordings:

Before:
<img width="1919" height="865" alt="image" src="https://github.com/user-attachments/assets/2c366020-0f3a-43bf-b675-2ae894dbdb4a" />


After:
<img width="1918" height="873" alt="image" src="https://github.com/user-attachments/assets/1fe4c859-68d7-45ac-8745-c785d664cc12" />


https://github.com/user-attachments/assets/23988c23-4ff3-4461-a6cc-b7701a50dbd4


###  Additional Notes:
This PR addresses issue #355 by standardizing platform branding and improving organization discoverability across the DebateAI interface.

The update focuses on replacing legacy "Argue-Hub" references with "DebateAI" to ensure consistent product identity across all navigation components, including the Header, Sidebar, and key pages.

Additionally, this PR introduces interactive AOSSIE organization discovery elements by adding clickable AOSSIE logos across major entry points (Home, Start Debate, Header, Sidebar), redirecting users to the official AOSSIE website. This helps improve awareness of the organization maintaining the project.

UI enhancements include subtle micro-interactions, such as hover-based visual feedback on support-related elements, to improve user engagement and interface responsiveness.

These changes are purely frontend-focused and do not affect backend functionality or application logic.

All updates were tested locally to ensure:
- Consistent branding across the interface
- Correct navigation behavior for AOSSIE links
- No regressions in existing UI components
- Proper rendering across different screen sizes

This PR complements the work done in #353 (Support Open Source Hub) and ensures visual and branding consistency across related components.

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [x] This PR contains AI-generated code.


I have used the following AI models and tools: Gemini CLI , Claude


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication-aware header with sign-in/out controls and updated DebateAI branding
  * "Play Bot" now routes to a bot-selection flow when signed in
  * About and Support DebateAI exposed as public pages

* **Style**
  * Footer shows a dynamic year range and linked organization branding
  * Organization logo/link promo blocks added across pages
  * Refreshed header, navigation, notifications, and mobile drawer styling and transitions

* **UX**
  * Improved breadcrumbs and clearer navigation labels
<!-- end of auto-generated comment: release notes by coderabbit.ai -->