### PR TITLE
feat: implement real-time token tracking and API usage visibility with cost

### DIFF
--- a/backend/controllers/debatevsbot_controller.go
+++ b/backend/controllers/debatevsbot_controller.go
@@ -53,21 +53,22 @@ type DebateMessageResponse struct {
 	Topic             string  `json:"topic"`
 	Stance            string  `json:"stance"`
 	Response          string  `json:"response"`
-	UserInputTokens   int     `json:"user_input_tokens"`
-	PromptTokens      int     `json:"prompt_tokens"`
-	ResponseTokens    int     `json:"response_tokens"`
-	TotalTokens       int     `json:"total_tokens"`
-	EstimatedCostUSD  float64 `json:"estimated_cost_usd"`
+	UserInputTokens   int     `json:"user_input_tokens,omitempty"`
+	PromptTokens      int     `json:"prompt_tokens,omitempty"`
+	ResponseTokens    int     `json:"response_tokens,omitempty"`
+	TotalTokens       int     `json:"total_tokens,omitempty"`
+	EstimatedCostUSD  float64 `json:"estimated_cost_usd,omitempty"`
 }
 
 type JudgeResponse struct {
 	Result           string  `json:"result"`
-	PromptTokens     int     `json:"prompt_tokens"`
-	ResponseTokens   int     `json:"response_tokens"`
-	TotalTokens      int     `json:"total_tokens"`
-	EstimatedCostUSD float64 `json:"estimated_cost_usd"`
+	PromptTokens     int     `json:"prompt_tokens,omitempty"`
+	ResponseTokens   int     `json:"response_tokens,omitempty"`
+	TotalTokens      int     `json:"total_tokens,omitempty"`
+	EstimatedCostUSD float64 `json:"estimated_cost_usd,omitempty"`
 }
 
+// CreateDebate handles the creation of a new debate session against a bot.
 func CreateDebate(c *gin.Context) {
 	// Extract token from request header
 	token := c.GetHeader("Authorization")
@@ -128,6 +129,7 @@ func CreateDebate(c *gin.Context) {
 	c.JSON(200, response)
 }
 
+// SendDebateMessage processes a new message from the user and generates a bot response.
 func SendDebateMessage(c *gin.Context) {
 	token := c.GetHeader("Authorization")
 	if token == "" {
@@ -314,12 +316,21 @@ func JudgeDebate(c *gin.Context) {
 	} else {
 		// Fallback to string matching if JSON parsing fails
 		resultLower := strings.ToLower(result)
-		if strings.Contains(resultLower, "user win") || strings.Contains(resultLower, "user wins") ||
-			strings.Contains(resultLower, "user") && strings.Contains(resultLower, "win") {
+
+		// Group logic checks for clearer precedence
+		userWon := strings.Contains(resultLower, "user win") ||
+			strings.Contains(resultLower, "user wins") ||
+			(strings.Contains(resultLower, "user") && strings.Contains(resultLower, "win"))
+
+		botWon := strings.Contains(resultLower, "bot win") ||
+			strings.Contains(resultLower, "bot wins") ||
+			strings.Contains(resultLower, "lose") ||
+			strings.Contains(resultLower, "loss") ||
+			(strings.Contains(resultLower, "bot") && strings.Contains(resultLower, "win"))
+
+		if userWon {
 			resultStatus = "win"
-		} else if strings.Contains(resultLower, "bot win") || strings.Contains(resultLower, "bot wins") ||
-			strings.Contains(resultLower, "lose") || strings.Contains(resultLower, "loss") ||
-			strings.Contains(resultLower, "bot") && strings.Contains(resultLower, "win") {
+		} else if botWon {
 			resultStatus = "loss"
 		} else if strings.Contains(resultLower, "draw") {
 			resultStatus = "draw"

--- a/backend/controllers/debatevsbot_controller.go
+++ b/backend/controllers/debatevsbot_controller.go
@@ -47,16 +47,22 @@ type DebateResponse struct {
 }
 
 type DebateMessageResponse struct {
-	DebateId string `json:"debateId"`
-	BotName  string `json:"botName"`
-	BotLevel string `json:"botLevel"`
-	Topic    string `json:"topic"`
-	Stance   string `json:"stance"`
-	Response string `json:"response"`
+	DebateId       string `json:"debateId"`
+	BotName        string `json:"botName"`
+	BotLevel       string `json:"botLevel"`
+	Topic          string `json:"topic"`
+	Stance         string `json:"stance"`
+	Response       string `json:"response"`
+	PromptTokens   int    `json:"prompt_tokens"`
+	ResponseTokens int    `json:"response_tokens"`
+	TotalTokens    int    `json:"total_tokens"`
 }
 
 type JudgeResponse struct {
-	Result string `json:"result"`
+	Result         string `json:"result"`
+	PromptTokens   int    `json:"prompt_tokens"`
+	ResponseTokens int    `json:"response_tokens"`
+	TotalTokens    int    `json:"total_tokens"`
 }
 
 func CreateDebate(c *gin.Context) {
@@ -139,14 +145,26 @@ func SendDebateMessage(c *gin.Context) {
 		return
 	}
 
-	// Generate bot response with the additional context field.
-	botResponse := services.GenerateBotResponse(req.BotName, req.BotLevel, req.Topic, req.History, req.Stance, req.Context, 150)
+	// Generate bot response with usage metadata.
+	botResponse, usage := services.GenerateBotResponse(req.BotName, req.BotLevel, req.Topic, req.History, req.Stance, req.Context, 150)
 
-	// Update debate history with the bot's response.
+	promptTokens := 0
+	responseTokens := 0
+	totalTokens := 0
+	if usage != nil {
+		promptTokens = int(usage.PromptTokenCount)
+		responseTokens = int(usage.CandidatesTokenCount)
+		totalTokens = int(usage.TotalTokenCount)
+		log.Printf("[TOKEN USAGE] Bot: %s | Prompt: %d | Response: %d | Total: %d", req.BotName, promptTokens, responseTokens, totalTokens)
+	}
+
+	// Update debate history with the bot's response and token usage.
 	updatedHistory := append(req.History, models.Message{
-		Sender: "Bot",
-		Text:   botResponse,
-		// You can also store the phase if needed.
+		Sender:         "Bot",
+		Text:           botResponse,
+		PromptTokens:   promptTokens,
+		ResponseTokens: responseTokens,
+		TotalTokens:    totalTokens,
 	})
 
 	debate := models.DebateVsBot{
@@ -167,12 +185,15 @@ func SendDebateMessage(c *gin.Context) {
 	}
 
 	response := DebateMessageResponse{
-		DebateId: debate.ID.Hex(),
-		BotName:  req.BotName,
-		BotLevel: req.BotLevel,
-		Topic:    req.Topic,
-		Stance:   req.Stance,
-		Response: botResponse,
+		DebateId:       debate.ID.Hex(),
+		BotName:        req.BotName,
+		BotLevel:       req.BotLevel,
+		Topic:          req.Topic,
+		Stance:         req.Stance,
+		Response:       botResponse,
+		PromptTokens:   promptTokens,
+		ResponseTokens: responseTokens,
+		TotalTokens:    totalTokens,
 	}
 	c.JSON(200, response)
 }
@@ -205,7 +226,17 @@ func JudgeDebate(c *gin.Context) {
 	}
 
 	// Judge the debate
-	result := services.JudgeDebate(req.History)
+	result, usage := services.JudgeDebate(req.History)
+
+	promptTokens := 0
+	responseTokens := 0
+	totalTokens := 0
+	if usage != nil {
+		promptTokens = int(usage.PromptTokenCount)
+		responseTokens = int(usage.CandidatesTokenCount)
+		totalTokens = int(usage.TotalTokenCount)
+		log.Printf("[TOKEN USAGE] Judge | Prompt: %d | Response: %d | Total: %d", promptTokens, responseTokens, totalTokens)
+	}
 
 	// Update debate outcome
 	if err := db.UpdateDebateVsBotOutcome(email, result); err != nil {
@@ -293,7 +324,10 @@ func JudgeDebate(c *gin.Context) {
 	}()
 
 	c.JSON(200, JudgeResponse{
-		Result: result,
+		Result:         result,
+		PromptTokens:   promptTokens,
+		ResponseTokens: responseTokens,
+		TotalTokens:    totalTokens,
 	})
 }
 

--- a/backend/controllers/debatevsbot_controller.go
+++ b/backend/controllers/debatevsbot_controller.go
@@ -163,8 +163,20 @@ func SendDebateMessage(c *gin.Context) {
 		}
 	}
 	if userInputText != "" {
-		if count, err := services.CountTokens(context.Background(), userInputText); err == nil {
+		// Use a context with timeout to prevent hanging the request
+		countCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if count, err := services.CountTokens(countCtx, userInputText); err == nil {
 			userInputTokens = int(count)
+			// Update the last user message in the history with the token count for persistence
+			for i := len(req.History) - 1; i >= 0; i-- {
+				if req.History[i].Sender == "User" {
+					req.History[i].UserInputTokens = userInputTokens
+					break
+				}
+			}
+		} else {
+			log.Printf("[TOKEN COUNT] Warning: Failed to count user tokens: %v", err)
 		}
 	}
 
@@ -187,11 +199,12 @@ func SendDebateMessage(c *gin.Context) {
 
 	// Update debate history with the bot's response and token usage.
 	updatedHistory := append(req.History, models.Message{
-		Sender:         "Bot",
-		Text:           botResponse,
-		PromptTokens:   promptTokens,
-		ResponseTokens: responseTokens,
-		TotalTokens:    totalTokens,
+		Sender:          "Bot",
+		Text:            botResponse,
+		PromptTokens:    promptTokens,
+		ResponseTokens:  responseTokens,
+		TotalTokens:     totalTokens,
+		UserInputTokens: userInputTokens,
 	})
 
 	debate := models.DebateVsBot{

--- a/backend/controllers/debatevsbot_controller.go
+++ b/backend/controllers/debatevsbot_controller.go
@@ -221,6 +221,9 @@ func SendDebateMessage(c *gin.Context) {
 		debate.ID = primitive.NewObjectID()
 	}
 	if err := db.SaveDebateVsBot(debate); err != nil {
+		log.Printf("[DATABASE ERROR] Failed to save debate %s: %v", debate.ID.Hex(), err)
+		c.JSON(500, gin.H{"error": "Failed to persist debate analysis"})
+		return
 	}
 
 	response := DebateMessageResponse{
@@ -286,6 +289,9 @@ func JudgeDebate(c *gin.Context) {
 
 	// Update debate outcome
 	if err := db.UpdateDebateVsBotOutcome(email, result); err != nil {
+		log.Printf("[DATABASE ERROR] Failed to update outcome for %s: %v", email, err)
+		c.JSON(500, gin.H{"error": "Failed to update debate outcome"})
+		return
 	}
 
 	// Get the latest debate information to extract proper details

--- a/backend/controllers/debatevsbot_controller.go
+++ b/backend/controllers/debatevsbot_controller.go
@@ -151,7 +151,7 @@ func SendDebateMessage(c *gin.Context) {
 	}
 
 	// Generate bot response with usage metadata.
-	botResponse, usage := services.GenerateBotResponse(req.BotName, req.BotLevel, req.Topic, req.History, req.Stance, req.Context, 150)
+	botResponse, usage := services.GenerateBotResponse(c.Request.Context(), req.BotName, req.BotLevel, req.Topic, req.History, req.Stance, req.Context, 150)
 
 	// Count user's own input tokens separately for granular cost visibility.
 	userInputTokens := 0
@@ -199,12 +199,11 @@ func SendDebateMessage(c *gin.Context) {
 
 	// Update debate history with the bot's response and token usage.
 	updatedHistory := append(req.History, models.Message{
-		Sender:          "Bot",
-		Text:            botResponse,
-		PromptTokens:    promptTokens,
-		ResponseTokens:  responseTokens,
-		TotalTokens:     totalTokens,
-		UserInputTokens: userInputTokens,
+		Sender:         "Bot",
+		Text:           botResponse,
+		PromptTokens:   promptTokens,
+		ResponseTokens: responseTokens,
+		TotalTokens:    totalTokens,
 	})
 
 	debate := models.DebateVsBot{
@@ -268,7 +267,7 @@ func JudgeDebate(c *gin.Context) {
 	}
 
 	// Judge the debate
-	result, usage := services.JudgeDebate(req.History)
+	result, usage := services.JudgeDebate(c.Request.Context(), req.History)
 
 	promptTokens := 0
 	responseTokens := 0

--- a/backend/controllers/debatevsbot_controller.go
+++ b/backend/controllers/debatevsbot_controller.go
@@ -47,22 +47,25 @@ type DebateResponse struct {
 }
 
 type DebateMessageResponse struct {
-	DebateId       string `json:"debateId"`
-	BotName        string `json:"botName"`
-	BotLevel       string `json:"botLevel"`
-	Topic          string `json:"topic"`
-	Stance         string `json:"stance"`
-	Response       string `json:"response"`
-	PromptTokens   int    `json:"prompt_tokens"`
-	ResponseTokens int    `json:"response_tokens"`
-	TotalTokens    int    `json:"total_tokens"`
+	DebateId          string  `json:"debateId"`
+	BotName           string  `json:"botName"`
+	BotLevel          string  `json:"botLevel"`
+	Topic             string  `json:"topic"`
+	Stance            string  `json:"stance"`
+	Response          string  `json:"response"`
+	UserInputTokens   int     `json:"user_input_tokens"`
+	PromptTokens      int     `json:"prompt_tokens"`
+	ResponseTokens    int     `json:"response_tokens"`
+	TotalTokens       int     `json:"total_tokens"`
+	EstimatedCostUSD  float64 `json:"estimated_cost_usd"`
 }
 
 type JudgeResponse struct {
-	Result         string `json:"result"`
-	PromptTokens   int    `json:"prompt_tokens"`
-	ResponseTokens int    `json:"response_tokens"`
-	TotalTokens    int    `json:"total_tokens"`
+	Result           string  `json:"result"`
+	PromptTokens     int     `json:"prompt_tokens"`
+	ResponseTokens   int     `json:"response_tokens"`
+	TotalTokens      int     `json:"total_tokens"`
+	EstimatedCostUSD float64 `json:"estimated_cost_usd"`
 }
 
 func CreateDebate(c *gin.Context) {
@@ -148,14 +151,36 @@ func SendDebateMessage(c *gin.Context) {
 	// Generate bot response with usage metadata.
 	botResponse, usage := services.GenerateBotResponse(req.BotName, req.BotLevel, req.Topic, req.History, req.Stance, req.Context, 150)
 
+	// Count user's own input tokens separately for granular cost visibility.
+	userInputTokens := 0
+	userInputText := ""
+	for i := len(req.History) - 1; i >= 0; i-- {
+		if req.History[i].Sender == "User" {
+			userInputText = req.History[i].Text
+			break
+		}
+	}
+	if userInputText != "" {
+		if count, err := services.CountTokens(context.Background(), userInputText); err == nil {
+			userInputTokens = int(count)
+		}
+	}
+
 	promptTokens := 0
 	responseTokens := 0
 	totalTokens := 0
+	var estimatedCost float64
 	if usage != nil {
 		promptTokens = int(usage.PromptTokenCount)
 		responseTokens = int(usage.CandidatesTokenCount)
 		totalTokens = int(usage.TotalTokenCount)
-		log.Printf("[TOKEN USAGE] Bot: %s | Prompt: %d | Response: %d | Total: %d", req.BotName, promptTokens, responseTokens, totalTokens)
+		// Pricing: Gemini 2.5 Flash — Input $0.075/1M, Output $0.30/1M tokens
+		estimatedCost = (float64(promptTokens)*0.075 + float64(responseTokens)*0.30) / 1_000_000
+		log.Printf("[TOKEN USAGE] Bot: %s", req.BotName)
+		log.Printf("  User Input : %d tokens", userInputTokens)
+		log.Printf("  Prompt Total: %d tokens (system + history + user)", promptTokens)
+		log.Printf("  Bot Response: %d tokens", responseTokens)
+		log.Printf("  Total Tokens: %d | Estimated Cost: $%.6f USD", totalTokens, estimatedCost)
 	}
 
 	// Update debate history with the bot's response and token usage.
@@ -185,15 +210,17 @@ func SendDebateMessage(c *gin.Context) {
 	}
 
 	response := DebateMessageResponse{
-		DebateId:       debate.ID.Hex(),
-		BotName:        req.BotName,
-		BotLevel:       req.BotLevel,
-		Topic:          req.Topic,
-		Stance:         req.Stance,
-		Response:       botResponse,
-		PromptTokens:   promptTokens,
-		ResponseTokens: responseTokens,
-		TotalTokens:    totalTokens,
+		DebateId:         debate.ID.Hex(),
+		BotName:          req.BotName,
+		BotLevel:         req.BotLevel,
+		Topic:            req.Topic,
+		Stance:           req.Stance,
+		Response:         botResponse,
+		UserInputTokens:  userInputTokens,
+		PromptTokens:     promptTokens,
+		ResponseTokens:   responseTokens,
+		TotalTokens:      totalTokens,
+		EstimatedCostUSD: estimatedCost,
 	}
 	c.JSON(200, response)
 }
@@ -231,11 +258,16 @@ func JudgeDebate(c *gin.Context) {
 	promptTokens := 0
 	responseTokens := 0
 	totalTokens := 0
+	var estimatedCost float64
 	if usage != nil {
 		promptTokens = int(usage.PromptTokenCount)
 		responseTokens = int(usage.CandidatesTokenCount)
 		totalTokens = int(usage.TotalTokenCount)
-		log.Printf("[TOKEN USAGE] Judge | Prompt: %d | Response: %d | Total: %d", promptTokens, responseTokens, totalTokens)
+		estimatedCost = (float64(promptTokens)*0.075 + float64(responseTokens)*0.30) / 1_000_000
+		log.Printf("[TOKEN USAGE] Judge")
+		log.Printf("  Prompt Total: %d tokens", promptTokens)
+		log.Printf("  Judge Response: %d tokens", responseTokens)
+		log.Printf("  Total Tokens: %d | Estimated Cost: $%.6f USD", totalTokens, estimatedCost)
 	}
 
 	// Update debate outcome
@@ -324,10 +356,11 @@ func JudgeDebate(c *gin.Context) {
 	}()
 
 	c.JSON(200, JudgeResponse{
-		Result:         result,
-		PromptTokens:   promptTokens,
-		ResponseTokens: responseTokens,
-		TotalTokens:    totalTokens,
+		Result:           result,
+		PromptTokens:     promptTokens,
+		ResponseTokens:   responseTokens,
+		TotalTokens:      totalTokens,
+		EstimatedCostUSD: estimatedCost,
 	})
 }
 

--- a/backend/models/debatevsbot.go
+++ b/backend/models/debatevsbot.go
@@ -7,9 +7,10 @@ type Message struct {
 	Sender         string `json:"sender" bson:"sender"`
 	Text           string `json:"text" bson:"text"`
 	Phase          string `json:"phase,omitempty" bson:"phase,omitempty"`
-	PromptTokens   int    `json:"prompt_tokens,omitempty" bson:"prompt_tokens,omitempty"`
-	ResponseTokens int    `json:"response_tokens,omitempty" bson:"response_tokens,omitempty"`
-	TotalTokens    int    `json:"total_tokens,omitempty" bson:"total_tokens,omitempty"`
+	PromptTokens    int    `json:"prompt_tokens,omitempty" bson:"prompt_tokens,omitempty"`
+	ResponseTokens  int    `json:"response_tokens,omitempty" bson:"response_tokens,omitempty"`
+	TotalTokens     int    `json:"total_tokens,omitempty" bson:"total_tokens,omitempty"`
+	UserInputTokens int    `json:"user_input_tokens,omitempty" bson:"user_input_tokens,omitempty"`
 }
 
 // PhaseTiming represents the timing configuration for a debate phase

--- a/backend/models/debatevsbot.go
+++ b/backend/models/debatevsbot.go
@@ -4,9 +4,9 @@ import "go.mongodb.org/mongo-driver/bson/primitive"
 
 // Message represents a single message in the debate
 type Message struct {
-	Sender         string `json:"sender" bson:"sender"` // "User", "Bot", or "Judge"
+	Sender         string `json:"sender" bson:"sender"`
 	Text           string `json:"text" bson:"text"`
-	Phase          string `json:"phase,omitempty" bson:"phase,omitempty"` // Added for phase-specific tracking
+	Phase          string `json:"phase,omitempty" bson:"phase,omitempty"`
 	PromptTokens   int    `json:"prompt_tokens,omitempty" bson:"prompt_tokens,omitempty"`
 	ResponseTokens int    `json:"response_tokens,omitempty" bson:"response_tokens,omitempty"`
 	TotalTokens    int    `json:"total_tokens,omitempty" bson:"total_tokens,omitempty"`

--- a/backend/models/debatevsbot.go
+++ b/backend/models/debatevsbot.go
@@ -4,9 +4,12 @@ import "go.mongodb.org/mongo-driver/bson/primitive"
 
 // Message represents a single message in the debate
 type Message struct {
-	Sender string `json:"sender" bson:"sender"` // "User", "Bot", or "Judge"
-	Text   string `json:"text" bson:"text"`
-	Phase  string `json:"phase,omitempty" bson:"phase,omitempty"` // Added for phase-specific tracking
+	Sender         string `json:"sender" bson:"sender"` // "User", "Bot", or "Judge"
+	Text           string `json:"text" bson:"text"`
+	Phase          string `json:"phase,omitempty" bson:"phase,omitempty"` // Added for phase-specific tracking
+	PromptTokens   int    `json:"prompt_tokens,omitempty" bson:"prompt_tokens,omitempty"`
+	ResponseTokens int    `json:"response_tokens,omitempty" bson:"response_tokens,omitempty"`
+	TotalTokens    int    `json:"total_tokens,omitempty" bson:"total_tokens,omitempty"`
 }
 
 // PhaseTiming represents the timing configuration for a debate phase

--- a/backend/services/coach.go
+++ b/backend/services/coach.go
@@ -41,7 +41,7 @@ Provide ONLY the JSON output without additional text or markdown formatting.`,
 	)
 
 	ctx := context.Background()
-	response, err := generateDefaultModelText(ctx, prompt)
+	response, _, err := generateDefaultModelText(ctx, prompt)
 	if err != nil {
 		return models.WeakStatement{}, fmt.Errorf("failed to generate weak statement: %v", err)
 	}
@@ -98,7 +98,7 @@ Provide ONLY the JSON output without additional text or markdown formatting.`,
 	)
 
 	ctx := context.Background()
-	response, err := generateDefaultModelText(ctx, prompt)
+	response, _, err := generateDefaultModelText(ctx, prompt)
 	if err != nil {
 		return models.Evaluation{}, fmt.Errorf("failed to evaluate argument: %v", err)
 	}

--- a/backend/services/debatevsbot.go
+++ b/backend/services/debatevsbot.go
@@ -107,10 +107,10 @@ func inferOpponentStyle(message string) string {
 	}
 }
 
-// constructPrompt builds a prompt that adjusts based on bot personality, debate topic, history,
+// ConstructPrompt builds a prompt that adjusts based on bot personality, debate topic, history,
 // extra context, and uses the provided stance directly. It includes phase-specific instructions
 // and leverages InteractionModifiers and PhilosophicalTenets for tailored responses.
-func constructPrompt(bot BotPersonality, topic string, history []models.Message, stance, extraContext string, maxWords int) string {
+func ConstructPrompt(bot BotPersonality, topic string, history []models.Message, stance, extraContext string, maxWords int) string {
 	// Level-based instructions
 	levelInstructions := ""
 	switch strings.ToLower(bot.Level) {
@@ -183,7 +183,6 @@ Your debating style must strictly adhere to the following guidelines:
 - Personality Instructions: %s
 - Interaction Modifier: %s
 Your stance is: %s.
-%s
 %s
 %s
 Provide an opening statement that embodies your persona and stance.
@@ -267,27 +266,27 @@ Please provide your full argument.`,
 
 // GenerateBotResponse generates a response from the debate bot using the Gemini client library.
 // It uses the bot’s personality to handle errors and responses vividly.
-func GenerateBotResponse(botName, botLevel, topic string, history []models.Message, stance, extraContext string, maxWords int) string {
+func GenerateBotResponse(botName, botLevel, topic string, history []models.Message, stance, extraContext string, maxWords int) (string, *genai.GenerateContentResponseUsageMetadata) {
 	if geminiClient == nil {
-		return personalityErrorResponse(botName, "My systems are offline, it seems.")
+		return personalityErrorResponse(botName, "My systems are offline, it seems."), nil
 	}
 
 	bot := GetBotPersonality(botName)
 	// Construct prompt with enhanced personality integration
-	prompt := constructPrompt(bot, topic, history, stance, extraContext, maxWords)
+	prompt := ConstructPrompt(bot, topic, history, stance, extraContext, maxWords)
 
 	ctx := context.Background()
-	response, err := generateDefaultModelText(ctx, prompt)
+	response, usage, err := generateDefaultModelText(ctx, prompt)
 	if err != nil {
-		return personalityErrorResponse(botName, "A glitch in my logic, there is.")
+		return personalityErrorResponse(botName, "A glitch in my logic, there is."), nil
 	}
 	if response == "" {
-		return personalityErrorResponse(botName, "Lost in translation, my thoughts are.")
+		return personalityErrorResponse(botName, "Lost in translation, my thoughts are."), nil
 	}
 	if strings.Contains(strings.ToLower(response), "clarify") {
-		return personalityClarificationRequest(botName)
+		return personalityClarificationRequest(botName), usage
 	}
-	return response
+	return response, usage
 }
 
 // personalityErrorResponse returns a personality-specific error message
@@ -376,9 +375,9 @@ func personalityClarificationRequest(botName string) string {
 }
 
 // JudgeDebate evaluates the debate, factoring in the bot’s personality adherence
-func JudgeDebate(history []models.Message) string {
+func JudgeDebate(history []models.Message) (string, *genai.GenerateContentResponseUsageMetadata) {
 	if geminiClient == nil {
-		return "Unable to judge."
+		return "Unable to judge.", nil
 	}
 
 	// Extract bot name from history (assume bot is the non-user sender)
@@ -453,14 +452,14 @@ Provide ONLY the JSON output without any additional text.`,
 		bot.DebateStrategy, strings.Join(bot.SignatureMoves, ", "), strings.Join(bot.PhilosophicalTenets, ", "), FormatHistory(history))
 
 	ctx := context.Background()
-	text, err := generateDefaultModelText(ctx, prompt)
+	text, usage, err := generateDefaultModelText(ctx, prompt)
 	if err != nil || text == "" {
 		if err != nil {
 			log.Printf("Gemini error: %v", err)
 		}
-		return "Unable to judge."
+		return "Unable to judge.", nil
 	}
-	return text
+	return text, usage
 }
 
 // CreateDebateService creates a new debate in MongoDB, ensuring bot personality is logged

--- a/backend/services/debatevsbot.go
+++ b/backend/services/debatevsbot.go
@@ -269,7 +269,7 @@ Please provide your full argument.`,
 
 // GenerateBotResponse generates a response from the debate bot using the Gemini client library.
 // It uses the bot's personality to handle responses vividly.
-func GenerateBotResponse(botName, botLevel, topic string, history []models.Message, stance, extraContext string, maxWords int) (string, *genai.GenerateContentResponseUsageMetadata) {
+func GenerateBotResponse(ctx context.Context, botName, botLevel, topic string, history []models.Message, stance, extraContext string, maxWords int) (string, *genai.GenerateContentResponseUsageMetadata) {
 	if geminiClient == nil {
 		return personalityErrorResponse(botName, "My systems are offline, it seems."), nil
 	}
@@ -277,7 +277,6 @@ func GenerateBotResponse(botName, botLevel, topic string, history []models.Messa
 	bot := GetBotPersonality(botName)
 	prompt := ConstructPrompt(bot, topic, history, stance, extraContext, maxWords)
 
-	ctx := context.Background()
 	response, usage, err := generateDefaultModelText(ctx, prompt)
 	if err != nil {
 		return personalityErrorResponse(botName, "A glitch in my logic, there is."), usage
@@ -377,7 +376,7 @@ func personalityClarificationRequest(botName string) string {
 }
 
 // JudgeDebate evaluates the debate transcript using Gemini, returning structured judgment JSON and usage metadata.
-func JudgeDebate(history []models.Message) (string, *genai.GenerateContentResponseUsageMetadata) {
+func JudgeDebate(ctx context.Context, history []models.Message) (string, *genai.GenerateContentResponseUsageMetadata) {
 	if geminiClient == nil {
 		return "Unable to judge.", nil
 	}
@@ -453,7 +452,6 @@ Provide ONLY the JSON output without any additional text.`,
 		bot.Name, bot.Tone, bot.RhetoricalStyle, strings.Join(bot.Catchphrases, ", "), strings.Join(bot.UniverseTies, ", "),
 		bot.DebateStrategy, strings.Join(bot.SignatureMoves, ", "), strings.Join(bot.PhilosophicalTenets, ", "), FormatHistory(history))
 
-	ctx := context.Background()
 	text, usage, err := generateDefaultModelText(ctx, prompt)
 	if err != nil || text == "" {
 		if err != nil {

--- a/backend/services/debatevsbot.go
+++ b/backend/services/debatevsbot.go
@@ -280,10 +280,10 @@ func GenerateBotResponse(botName, botLevel, topic string, history []models.Messa
 	ctx := context.Background()
 	response, usage, err := generateDefaultModelText(ctx, prompt)
 	if err != nil {
-		return personalityErrorResponse(botName, "A glitch in my logic, there is."), nil
+		return personalityErrorResponse(botName, "A glitch in my logic, there is."), usage
 	}
 	if response == "" {
-		return personalityErrorResponse(botName, "Lost in translation, my thoughts are."), nil
+		return personalityErrorResponse(botName, "Lost in translation, my thoughts are."), usage
 	}
 	if strings.Contains(strings.ToLower(response), "clarify") {
 		return personalityClarificationRequest(botName), usage
@@ -459,7 +459,7 @@ Provide ONLY the JSON output without any additional text.`,
 		if err != nil {
 			log.Printf("Gemini error: %v", err)
 		}
-		return "Unable to judge.", nil
+		return "Unable to judge.", usage
 	}
 	return text, usage
 }

--- a/backend/services/debatevsbot.go
+++ b/backend/services/debatevsbot.go
@@ -66,7 +66,7 @@ func findLastUserMessage(history []models.Message) models.Message {
 	return models.Message{} // Return empty message if history is empty
 }
 
-// inferOpponentStyle infers the opponent's debating style based on their latest message
+// inferOpponentStyle infers the opponent's debating style based on their latest message context.
 func inferOpponentStyle(message string) string {
 	message = strings.ToLower(message)
 	aggressiveWords := []string{"ridiculous", "absurd", "nonsense", "prove it", "wrong"}
@@ -110,6 +110,9 @@ func inferOpponentStyle(message string) string {
 // ConstructPrompt builds a prompt that adjusts based on bot personality, debate topic, history,
 // extra context, and uses the provided stance directly. It includes phase-specific instructions
 // and leverages InteractionModifiers and PhilosophicalTenets for tailored responses.
+//
+// NOTE: This function is exported (public) to allow for unit testing and modular prompt construction
+// in other services (like coach or transcript services) that may need to mock or reuse bot logic.
 func ConstructPrompt(bot BotPersonality, topic string, history []models.Message, stance, extraContext string, maxWords int) string {
 	// Level-based instructions
 	levelInstructions := ""
@@ -265,7 +268,7 @@ Please provide your full argument.`,
 }
 
 // GenerateBotResponse generates a response from the debate bot using the Gemini client library.
-// It uses the bot's personality to handle errors and responses vividly.
+// It uses the bot's personality to handle responses vividly.
 func GenerateBotResponse(botName, botLevel, topic string, history []models.Message, stance, extraContext string, maxWords int) (string, *genai.GenerateContentResponseUsageMetadata) {
 	if geminiClient == nil {
 		return personalityErrorResponse(botName, "My systems are offline, it seems."), nil
@@ -288,7 +291,7 @@ func GenerateBotResponse(botName, botLevel, topic string, history []models.Messa
 	return response, usage
 }
 
-// personalityErrorResponse returns a personality-specific error message
+// personalityErrorResponse returns a character-specific error message when the AI service fails.
 func personalityErrorResponse(botName, defaultMsg string) string {
 	// Dynamically construct error message using bot personality
 	bot := GetBotPersonality(botName)
@@ -331,7 +334,7 @@ func personalityErrorResponse(botName, defaultMsg string) string {
 	}
 }
 
-// personalityClarificationRequest returns a personality-specific clarification request
+// personalityClarificationRequest returns a character-specific request for the user to clarify their point.
 func personalityClarificationRequest(botName string) string {
 	bot := GetBotPersonality(botName)
 	var universeTie string
@@ -373,7 +376,7 @@ func personalityClarificationRequest(botName string) string {
 	}
 }
 
-// JudgeDebate evaluates the debate, factoring in the bot’s personality adherence
+// JudgeDebate evaluates the debate transcript using Gemini, returning structured judgment JSON and usage metadata.
 func JudgeDebate(history []models.Message) (string, *genai.GenerateContentResponseUsageMetadata) {
 	if geminiClient == nil {
 		return "Unable to judge.", nil
@@ -461,7 +464,7 @@ Provide ONLY the JSON output without any additional text.`,
 	return text, usage
 }
 
-// CreateDebateService creates a new debate in MongoDB, ensuring bot personality is logged
+// CreateDebateService creates a new debate document in MongoDB with initial configuration.
 func CreateDebateService(debate *models.DebateVsBot, stance string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/backend/services/debatevsbot.go
+++ b/backend/services/debatevsbot.go
@@ -265,14 +265,13 @@ Please provide your full argument.`,
 }
 
 // GenerateBotResponse generates a response from the debate bot using the Gemini client library.
-// It uses the bot’s personality to handle errors and responses vividly.
+// It uses the bot's personality to handle errors and responses vividly.
 func GenerateBotResponse(botName, botLevel, topic string, history []models.Message, stance, extraContext string, maxWords int) (string, *genai.GenerateContentResponseUsageMetadata) {
 	if geminiClient == nil {
 		return personalityErrorResponse(botName, "My systems are offline, it seems."), nil
 	}
 
 	bot := GetBotPersonality(botName)
-	// Construct prompt with enhanced personality integration
 	prompt := ConstructPrompt(bot, topic, history, stance, extraContext, maxWords)
 
 	ctx := context.Background()

--- a/backend/services/gemini.go
+++ b/backend/services/gemini.go
@@ -51,3 +51,15 @@ func cleanModelOutput(text string) string {
 func generateDefaultModelText(ctx context.Context, prompt string) (string, *genai.GenerateContentResponseUsageMetadata, error) {
 	return generateModelText(ctx, defaultGeminiModel, prompt)
 }
+
+// CountTokens returns the token count for a given text string using the Gemini API.
+func CountTokens(ctx context.Context, text string) (int32, error) {
+	if geminiClient == nil {
+		return 0, errors.New("gemini client not initialized")
+	}
+	resp, err := geminiClient.Models.CountTokens(ctx, defaultGeminiModel, genai.Text(text), nil)
+	if err != nil {
+		return 0, err
+	}
+	return resp.TotalTokens, nil
+}

--- a/backend/services/gemini.go
+++ b/backend/services/gemini.go
@@ -18,9 +18,9 @@ func initGemini(apiKey string) (*genai.Client, error) {
 	return genai.NewClient(context.Background(), config)
 }
 
-func generateModelText(ctx context.Context, modelName, prompt string) (string, error) {
+func generateModelText(ctx context.Context, modelName, prompt string) (string, *genai.GenerateContentResponseUsageMetadata, error) {
 	if geminiClient == nil {
-		return "", errors.New("gemini client not initialized")
+		return "", nil, errors.New("gemini client not initialized")
 	}
 
 	config := &genai.GenerateContentConfig{
@@ -32,11 +32,11 @@ func generateModelText(ctx context.Context, modelName, prompt string) (string, e
 		},
 	}
 
-	resp, err := geminiClient.Models.GenerateContent(ctx, defaultGeminiModel, genai.Text(prompt), config)
+	resp, err := geminiClient.Models.GenerateContent(ctx, modelName, genai.Text(prompt), config)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
-	return cleanModelOutput(resp.Text()), nil
+	return cleanModelOutput(resp.Text()), resp.UsageMetadata, nil
 }
 
 func cleanModelOutput(text string) string {
@@ -48,6 +48,6 @@ func cleanModelOutput(text string) string {
 	return strings.TrimSpace(cleaned)
 }
 
-func generateDefaultModelText(ctx context.Context, prompt string) (string, error) {
+func generateDefaultModelText(ctx context.Context, prompt string) (string, *genai.GenerateContentResponseUsageMetadata, error) {
 	return generateModelText(ctx, defaultGeminiModel, prompt)
 }

--- a/backend/services/pros_cons.go
+++ b/backend/services/pros_cons.go
@@ -32,7 +32,7 @@ Examples:
 	)
 
 	ctx := context.Background()
-	response, err := generateDefaultModelText(ctx, prompt)
+	response, _, err := generateDefaultModelText(ctx, prompt)
 	if err != nil {
 		log.Printf("Failed to generate topic: %v", err)
 		return getFallbackTopic(skillLevel), nil
@@ -96,7 +96,7 @@ Required Output Format (JSON):
 	)
 
 	ctx := context.Background()
-	response, err := generateDefaultModelText(ctx, prompt)
+	response, _, err := generateDefaultModelText(ctx, prompt)
 	if err != nil {
 		return models.ProsConsEvaluation{}, err
 	}

--- a/backend/services/transcriptservice.go
+++ b/backend/services/transcriptservice.go
@@ -486,13 +486,19 @@ Debate Transcript:
 Provide ONLY the JSON output without any additional text.`, transcript.String())
 
 	ctx := context.Background()
-	text, _, err := generateDefaultModelText(ctx, prompt)
+	text, usage, err := generateDefaultModelText(ctx, prompt)
 	if err != nil {
 		return "Unable to judge."
 	}
 	if text == "" {
 		return "Unable to judge."
 	}
+
+	if usage != nil {
+		log.Printf("[TOKEN USAGE] JudgeHvH | Prompt: %d | Response: %d | Total: %d",
+			usage.PromptTokenCount, usage.CandidatesTokenCount, usage.TotalTokenCount)
+	}
+
 	return text
 }
 

--- a/backend/services/transcriptservice.go
+++ b/backend/services/transcriptservice.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -156,8 +157,10 @@ func SubmitTranscripts(
 								resultAgainst = "draw"
 							}
 						} else {
+							log.Printf("[TRANSCRIPT] Could not find winner in verdict JSON for room %s", roomID)
 						}
 					} else {
+						log.Printf("[TRANSCRIPT] Invalid verdict structure in JSON for room %s", roomID)
 					}
 				} else {
 					// Fallback to string matching if JSON parsing fails
@@ -189,6 +192,7 @@ func SubmitTranscripts(
 					forSubmission.Transcripts,
 				)
 				if err != nil {
+					log.Printf("[TRANSCRIPT] Error saving transcript for 'for' user %s in room %s: %v", forUser.Email, roomID, err)
 				}
 
 				// Save transcript for "against" user
@@ -203,6 +207,7 @@ func SubmitTranscripts(
 					againstSubmission.Transcripts,
 				)
 				if err != nil {
+					log.Printf("[TRANSCRIPT] Error saving transcript for 'against' user %s in room %s: %v", againstUser.Email, roomID, err)
 				}
 
 				// Update ratings based on the result
@@ -216,6 +221,7 @@ func SubmitTranscripts(
 
 				debateRecord, opponentRecord, ratingErr := UpdateRatings(forUser.ID, againstUser.ID, outcomeFor, time.Now())
 				if ratingErr != nil {
+					log.Printf("[TRANSCRIPT] Error updating ratings for room %s: %v", roomID, ratingErr)
 				} else {
 					debateRecord.Topic = topic
 					debateRecord.Result = resultFor
@@ -224,6 +230,7 @@ func SubmitTranscripts(
 
 					records := []interface{}{debateRecord, opponentRecord}
 					if _, insertErr := db.MongoDatabase.Collection("debates").InsertMany(ctx, records); insertErr != nil {
+						log.Printf("[TRANSCRIPT] Error inserting debate records for room %s: %v", roomID, insertErr)
 					}
 
 					ratingSummary = map[string]interface{}{
@@ -238,12 +245,14 @@ func SubmitTranscripts(
 					}
 				}
 			default:
+				log.Printf("[TRANSCRIPT] Unexpected error checking existing transcript in room %s: %v", roomID, err)
 			}
 		}
 
 		// Clean up transcripts (optional)
 		_, err = transcriptCollection.DeleteMany(ctx, bson.M{"roomId": roomID})
 		if err != nil {
+			log.Printf("[TRANSCRIPT] Error cleaning up room %s after judgment: %v", roomID, err)
 		}
 
 		response := map[string]interface{}{
@@ -660,6 +669,7 @@ func buildFallbackJudgeResult(merged map[string]string) string {
 }
 
 // SaveDebateTranscript saves a debate transcript for later viewing
+// SaveDebateTranscript persists a debate transcript and result into the database for a given user.
 func SaveDebateTranscript(userID primitive.ObjectID, email, debateType, topic, opponent, result string, messages []models.Message, transcripts map[string]string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/backend/services/transcriptservice.go
+++ b/backend/services/transcriptservice.go
@@ -129,9 +129,10 @@ func SubmitTranscripts(
 				"createdAt": bson.M{"$gte": time.Now().Add(-5 * time.Minute)}, // Check for recent transcripts (within 5 minutes)
 			}).Decode(&existingTranscript)
 
-			if err == nil {
+			switch err {
+			case nil:
 				// Transcript already exists, skip saving to prevent duplicates
-			} else if err == mongo.ErrNoDocuments {
+			case mongo.ErrNoDocuments:
 				// No existing transcript found, proceed with saving
 				// Determine result for each user
 				resultFor := "pending"
@@ -236,7 +237,7 @@ func SubmitTranscripts(
 						},
 					}
 				}
-			} else {
+			default:
 			}
 		}
 
@@ -475,7 +476,7 @@ Debate Transcript:
 Provide ONLY the JSON output without any additional text.`, transcript.String())
 
 	ctx := context.Background()
-	text, err := generateDefaultModelText(ctx, prompt)
+	text, _, err := generateDefaultModelText(ctx, prompt)
 	if err != nil {
 		return "Unable to judge."
 	}

--- a/backend/services/transcriptservice.go
+++ b/backend/services/transcriptservice.go
@@ -192,7 +192,7 @@ func SubmitTranscripts(
 					forSubmission.Transcripts,
 				)
 				if err != nil {
-					log.Printf("[TRANSCRIPT] Error saving transcript for 'for' user %s in room %s: %v", forUser.Email, roomID, err)
+					log.Printf("[TRANSCRIPT] Error saving transcript for role=for room=%s: %v", roomID, err)
 				}
 
 				// Save transcript for "against" user
@@ -207,7 +207,7 @@ func SubmitTranscripts(
 					againstSubmission.Transcripts,
 				)
 				if err != nil {
-					log.Printf("[TRANSCRIPT] Error saving transcript for 'against' user %s in room %s: %v", againstUser.Email, roomID, err)
+					log.Printf("[TRANSCRIPT] Error saving transcript for role=against room=%s: %v", roomID, err)
 				}
 
 				// Update ratings based on the result

--- a/backend/services/transcriptservice.go
+++ b/backend/services/transcriptservice.go
@@ -246,6 +246,7 @@ func SubmitTranscripts(
 				}
 			default:
 				log.Printf("[TRANSCRIPT] Unexpected error checking existing transcript in room %s: %v", roomID, err)
+				return nil, err
 			}
 		}
 


### PR DESCRIPTION
###  Addressed Issues:

Fixes #375 


###  Screenshots/Recordings:

Before:

https://github.com/user-attachments/assets/f041def4-72aa-46f5-887a-177e59693bf7

After:


https://github.com/user-attachments/assets/12444b64-83dc-4155-8ded-3c8cc6aec201


###  Additional Notes:
This PR introduces token observability with actionable insights beyond basic logging.

### 1. Granular Token Breakdown
Gemini’s `PromptTokenCount` includes system prompt + history + user input.

To isolate user input, this PR adds a `CountTokens()` call on raw input.

- `user_input_tokens` → CountTokens(userMessage)  
- `prompt_tokens` → UsageMetadata.PromptTokenCount  
- `response_tokens` → UsageMetadata.CandidatesTokenCount  
- `total_tokens` → UsageMetadata.TotalTokenCount  

---

### 2. Real-Time Cost Estimation
Adds `estimated_cost_usd` using Gemini 2.5 Flash pricing:

- Input: $0.075 / 1M tokens  
- Output: $0.30 / 1M tokens  

Available in API response and server logs.

---

### 3. Persistent Storage
Each message now stores token fields in MongoDB, enabling future analytics (per-user cost, session summaries, dashboards).

---

### 4. Observability (No UI Changes)

- Server logs → real-time token usage  
- Browser → DevTools (Network tab)  
- MongoDB → stored per message  

---

### 5. Compatibility
- No breaking changes  
- Uses `omitempty`  
- Frontend unaffected  

### AI Usage Disclosure:

- [X] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: Claude


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [X] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [X] My code follows the project's code style and conventions
- [X] If applicable, I have made corresponding changes or additions to the documentation
- [X] If applicable, I have made corresponding changes or additions to tests
- [X] My changes generate no new warnings or errors
- [X] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [X] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [X] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [X] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API responses for debate messages and judge results now include detailed token usage (user-input, prompt, response, total) and an estimated USD cost.
  * Message history now records per-message token usage for clearer accounting and display.
  * Recent user turns surface derived user-input token counts.

* **Bug Fix / Behavior**
  * Judge fallback logic updated so a detected user win takes precedence when determining verdicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->