### PR TITLE
Fixed: Prevented authenticated users from re-accessing /auth route

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,7 +49,7 @@ function AppRoutes() {
   if (!authContext) {
     throw new Error('AppRoutes must be used within an AuthProvider');
   }
-  const { isAuthenticated, loading } = authContext;
+  const { isAuthenticated } = authContext;
   return (
     <Routes>
       {/* Public routes */}
@@ -60,12 +60,7 @@ function AppRoutes() {
         }
       />
       <Route path='/auth'
-        element={
-          loading ? (
-            <div>Loading...</div>
-          ) : isAuthenticated ?
-            (<Navigate to='/startDebate' replace />)
-            : (<Authentication />)}
+        element={ isAuthenticated ? <Navigate to='/startDebate' replace/> : <Authentication/> }
       />
       <Route path='/admin/login' element={<AdminSignup />} />
       <Route path='/admin/dashboard' element={<AdminDashboard />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -59,7 +59,9 @@ function AppRoutes() {
           isAuthenticated ? <Navigate to='/startDebate' replace /> : <Home />
         }
       />
-      <Route path='/auth' element={<Authentication />} />
+      <Route path='/auth'
+        element={ isAuthenticated ? <Navigate to='/startDebate' replace/> : <Authentication/> }
+      />
       <Route path='/admin/login' element={<AdminSignup />} />
       <Route path='/admin/dashboard' element={<AdminDashboard />} />
       {/* Public routes with layout */}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,7 +49,7 @@ function AppRoutes() {
   if (!authContext) {
     throw new Error('AppRoutes must be used within an AuthProvider');
   }
-  const { isAuthenticated } = authContext;
+  const { isAuthenticated, loading } = authContext;
   return (
     <Routes>
       {/* Public routes */}
@@ -60,7 +60,12 @@ function AppRoutes() {
         }
       />
       <Route path='/auth'
-        element={ isAuthenticated ? <Navigate to='/startDebate' replace/> : <Authentication/> }
+        element={
+          loading ? (
+            <div>Loading...</div>
+          ) : isAuthenticated ?
+            (<Navigate to='/startDebate' replace />)
+            : (<Authentication />)}
       />
       <Route path='/admin/login' element={<AdminSignup />} />
       <Route path='/admin/dashboard' element={<AdminDashboard />} />

--- a/frontend/src/context/authContext.tsx
+++ b/frontend/src/context/authContext.tsx
@@ -53,13 +53,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   };
 
   const verifyToken = useCallback(async () => {
-    setLoading(true);
-
     const storedToken = localStorage.getItem('token');
-    if (!storedToken) {
-      setLoading(false)
-      return
-    } ;
+    if (!storedToken) return;
     try {
       const response = await fetch(`${baseURL}/verifyToken`, {
         method: 'POST',
@@ -72,7 +67,6 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         setToken(null);
         setUser(null);
         navigate('/login');
-        setLoading(false);
         return;
       }
       setToken(storedToken);
@@ -114,9 +108,6 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     } catch (error) {
       console.log('error', error);
       logout();
-    }
-    finally {
-      setLoading(false);
     }
   }, [setUser]);
 

--- a/frontend/src/context/authContext.tsx
+++ b/frontend/src/context/authContext.tsx
@@ -53,8 +53,13 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   };
 
   const verifyToken = useCallback(async () => {
+    setLoading(true);
+
     const storedToken = localStorage.getItem('token');
-    if (!storedToken) return;
+    if (!storedToken) {
+      setLoading(false)
+      return
+    } ;
     try {
       const response = await fetch(`${baseURL}/verifyToken`, {
         method: 'POST',
@@ -67,6 +72,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         setToken(null);
         setUser(null);
         navigate('/login');
+        setLoading(false);
         return;
       }
       setToken(storedToken);
@@ -108,6 +114,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     } catch (error) {
       console.log('error', error);
       logout();
+    }
+    finally {
+      setLoading(false);
     }
   }, [setUser]);
 


### PR DESCRIPTION
## Bug

When a user is already authenticated and manually navigates to `/auth` (e.g. via the URL bar), the app shows the login/signup page instead of redirecting them back into the app. This creates confusing UX, as it looks like the user has been logged out even though their session is still valid.

## Root Cause

 `/auth` was defined without any guard:

```jsx
<Route path='/auth' element={<Authentication />} />
```

Allowing authenticated users to access the authentication page,
Leading to confusion, unnecessary API Calls and can also occur tiny issues/bugs in future.

## Fix

Added the logic to the `/auth` route:

```jsx
<Route
  path='/auth'
  element={
    isAuthenticated ? <Navigate to='/startDebate' replace /> : <Authentication />
  }
/>
```

This ensures authenticated users are always redirected away from auth pages.

## Testing

* Logged in via Google OAuth
* Manually navigated to `/auth`

**Before fix:**
* Login/signup page was shown again

https://github.com/user-attachments/assets/6517d10c-cf39-49d7-92e3-a155662853b2


**After fix:**
* User is correctly redirected to `/startDebate`

https://github.com/user-attachments/assets/c11b9865-188f-44b5-a0c8-ccb4ed28fdb7





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authenticated users visiting the authentication page are now redirected to the debate start page.
  * Unauthenticated users continue to see the authentication screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->