### PR TITLE
fix: replace broken default avatar URLs and add fallback handling

### DIFF
--- a/backend/controllers/auth.go
+++ b/backend/controllers/auth.go
@@ -168,7 +168,7 @@ func SignUp(ctx *gin.Context) {
 		RD:               350.0,
 		Volatility:       0.06,
 		LastRatingUpdate: now,
-		AvatarURL:        "https://avatar.iran.liara.run/public/10",
+		AvatarURL:        "https://api.dicebear.com/9.x/big-ears/svg?seed=Jude",
 		Password:         string(hashedPassword),
 		IsVerified:       false,
 		VerificationCode: verificationCode,

--- a/backend/websocket/websocket.go
+++ b/backend/websocket/websocket.go
@@ -301,7 +301,7 @@ func WebsocketHandler(c *gin.Context) {
 	room.Mutex.Unlock()
 
 	if avatarURL == "" {
-		avatarURL = "https://avatar.iran.liara.run/public/31"
+		avatarURL = "https://api.dicebear.com/9.x/big-ears/svg?seed=Nolan"
 	}
 	if rating == 0 {
 		rating = 1500

--- a/frontend/src/Pages/DebateRoom.tsx
+++ b/frontend/src/Pages/DebateRoom.tsx
@@ -7,6 +7,7 @@ import JudgmentPopup from "@/components/JudgementPopup";
 import { Mic, MicOff } from "lucide-react";
 import { useAtom } from "jotai";
 import { userAtom } from "@/state/userAtom";
+import { DEFAULT_AVATAR_URL } from "@/constants/avatar";
 
 // Bot type definition (same as in BotSelection)
 interface Bot {
@@ -257,7 +258,7 @@ const DebateRoom: React.FC = () => {
 
   const bot = allBots.find((b) => b.name === debateData.botName) || allBots[0];
   const userAvatar =
-    user?.avatarUrl || "https://avatar.iran.liara.run/public/10";
+    user?.avatarUrl || DEFAULT_AVATAR_URL;
 
   const handleConcede = async () => {
     if (window.confirm("Are you sure you want to concede? This will count as a loss.")) {

--- a/frontend/src/Pages/OnlineDebateRoom.tsx
+++ b/frontend/src/Pages/OnlineDebateRoom.tsx
@@ -978,7 +978,7 @@ const OnlineDebateRoom = (): JSX.Element => {
                 avatarUrl:
                   currentUser.avatarUrl ||
                   localParticipant.avatarUrl ||
-                  "https://avatar.iran.liara.run/public/40",
+                  "https://api.dicebear.com/9.x/big-ears/svg?seed=Felix",
                 displayName:
                   currentUser.displayName ||
                   localParticipant.displayName ||
@@ -996,7 +996,7 @@ const OnlineDebateRoom = (): JSX.Element => {
                 elo: currentUser.rating || 1500,
                 avatarUrl:
                   currentUser.avatarUrl ||
-                  "https://avatar.iran.liara.run/public/40",
+                  "https://api.dicebear.com/9.x/big-ears/svg?seed=Felix",
                 email: currentUser.email || "",
               };
               setLocalUser(fallbackLocal);
@@ -1008,7 +1008,7 @@ const OnlineDebateRoom = (): JSX.Element => {
                 ...opponentParticipant,
                 avatarUrl:
                   opponentParticipant.avatarUrl ||
-                  "https://avatar.iran.liara.run/public/31",
+                  "https://api.dicebear.com/9.x/big-ears/svg?seed=Nolan",
               };
               setOpponentUser(opponentData);
               localStorage.setItem(
@@ -1064,7 +1064,7 @@ const OnlineDebateRoom = (): JSX.Element => {
               elo: currentUser.rating || 1500,
               avatarUrl:
                 currentUser.avatarUrl ||
-                "https://avatar.iran.liara.run/public/40",
+                "https://api.dicebear.com/9.x/big-ears/svg?seed=Felix",
               displayName: currentUser.displayName || "You",
             };
             setLocalUser(fallbackLocalUser);
@@ -1252,7 +1252,7 @@ const OnlineDebateRoom = (): JSX.Element => {
                   ...opponentParticipant,
                   avatarUrl:
                     opponentParticipant.avatarUrl ||
-                    "https://avatar.iran.liara.run/public/31",
+                    "https://api.dicebear.com/9.x/big-ears/svg?seed=Nolan",
                 });
               } else {
                 setOpponentUser(null);
@@ -2183,7 +2183,7 @@ const OnlineDebateRoom = (): JSX.Element => {
                         src={
                           localUser?.avatarUrl ||
                           currentUser?.avatarUrl ||
-                          "https://avatar.iran.liara.run/public/40"
+                          "https://api.dicebear.com/9.x/big-ears/svg?seed=Felix"
                         }
                         alt="You"
                         className="w-20 h-20 rounded-full object-cover"
@@ -2243,7 +2243,7 @@ const OnlineDebateRoom = (): JSX.Element => {
                       <img
                         src={
                           opponentUser?.avatarUrl ||
-                          "https://avatar.iran.liara.run/public/31"
+                          "https://api.dicebear.com/9.x/big-ears/svg?seed=Nolan"
                         }
                         alt="Opponent"
                         className="w-20 h-20 rounded-full object-cover"
@@ -2387,7 +2387,7 @@ const OnlineDebateRoom = (): JSX.Element => {
                 src={
                   localUser?.avatarUrl ||
                   currentUser?.avatarUrl ||
-                  "https://avatar.iran.liara.run/public/40"
+                  "https://api.dicebear.com/9.x/big-ears/svg?seed=Felix"
                 }
                 alt="You"
                 className="w-full h-full rounded-full border border-orange-400 object-cover"
@@ -2451,7 +2451,7 @@ const OnlineDebateRoom = (): JSX.Element => {
               <img
                 src={
                   opponentUser?.avatarUrl ||
-                  "https://avatar.iran.liara.run/public/31"
+                  "https://api.dicebear.com/9.x/big-ears/svg?seed=Nolan"
                 }
                 alt="Opponent"
                 className="w-full h-full rounded-full border border-orange-400 object-cover"

--- a/frontend/src/Pages/Profile.tsx
+++ b/frontend/src/Pages/Profile.tsx
@@ -54,6 +54,7 @@ import {
 import { FaTrophy, FaMedal, FaAward } from "react-icons/fa";
 import { format, isSameDay, subDays } from "date-fns";
 import defaultAvatar from "@/assets/avatar2.jpg";
+import { DEFAULT_AVATAR_URL } from "@/constants/avatar";
 import {
   PieChart,
   Pie,
@@ -82,6 +83,20 @@ import {
   transcriptService,
   SavedDebateTranscript,
 } from "@/services/transcriptService";
+
+const handleProfileAvatarLoadError = (
+  event: React.SyntheticEvent<HTMLImageElement>
+) => {
+  const image = event.currentTarget;
+
+  if (image.src !== DEFAULT_AVATAR_URL) {
+    image.src = DEFAULT_AVATAR_URL;
+    return;
+  }
+
+  image.onerror = null;
+  image.src = defaultAvatar;
+};
 
 interface ProfileData {
   displayName: string;
@@ -770,8 +785,9 @@ const Profile: React.FC = () => {
         <div className="flex flex-col items-center mb-4">
           <div className="relative w-16 h-16 sm:w-20 sm:h-20 md:w-24 md:h-24 rounded-full overflow-hidden bg-muted flex-shrink-0 mb-2 border-2 border-primary shadow-md group">
             <img
-              src={profile.avatarUrl || defaultAvatar}
+              src={profile.avatarUrl || DEFAULT_AVATAR_URL}
               alt="Avatar"
+              onError={handleProfileAvatarLoadError}
               className="object-cover w-full h-full"
             />
             <button

--- a/frontend/src/Pages/TeamDebateRoom.tsx
+++ b/frontend/src/Pages/TeamDebateRoom.tsx
@@ -1799,7 +1799,7 @@ const TeamDebateRoom: React.FC = () => {
                             <div key={member.userId} className="flex items-center gap-3">
                               <div className="relative">
                                 <img
-                                  src={member.avatarUrl || "https://avatar.iran.liara.run/public/31"}
+                                  src={member.avatarUrl || "https://api.dicebear.com/9.x/big-ears/svg?seed=Nolan"}
                                   alt={member.displayName}
                                   className="w-10 h-10 rounded-full object-cover border-2 border-gray-300"
                                 />
@@ -1836,7 +1836,7 @@ const TeamDebateRoom: React.FC = () => {
                             <div key={member.userId} className="flex items-center gap-3">
                               <div className="relative">
                                 <img
-                                  src={member.avatarUrl || "https://avatar.iran.liara.run/public/31"}
+                                  src={member.avatarUrl || "https://api.dicebear.com/9.x/big-ears/svg?seed=Nolan"}
                                   alt={member.displayName}
                                   className="w-10 h-10 rounded-full object-cover border-2 border-gray-300"
                                 />

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -21,7 +21,20 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Button } from "@/components/ui/button";
 import debateAiLogo from "@/assets/aossie.png";
 import avatarImage from "@/assets/avatar2.jpg";
+import { DEFAULT_AVATAR_URL } from "@/constants/avatar";
 import { getNotifications, markNotificationAsRead, markAllNotificationsAsRead, deleteNotification, Notification } from "@/services/notificationService";
+
+const handleAvatarLoadError = (event: React.SyntheticEvent<HTMLImageElement>) => {
+  const image = event.currentTarget;
+
+  if (image.src !== DEFAULT_AVATAR_URL) {
+    image.src = DEFAULT_AVATAR_URL;
+    return;
+  }
+
+  image.onerror = null;
+  image.src = avatarImage;
+};
 
 /**
  * Header component providing breadcrumb navigation, notifications, 
@@ -219,8 +232,9 @@ function Header() {
                 className="focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-full transition-opacity"
               >
                 <img
-                  src={user?.avatarUrl || avatarImage}
+                  src={user?.avatarUrl || DEFAULT_AVATAR_URL}
                   alt="User avatar"
+                  onError={handleAvatarLoadError}
                   className="w-8 h-8 rounded-full border-2 border-border object-cover cursor-pointer hover:opacity-80 transition-opacity"
                 />
               </button>
@@ -229,8 +243,9 @@ function Header() {
               <div className="p-4 border-b border-border">
                 <div className="flex items-center gap-3 mb-3">
                   <img
-                    src={user?.avatarUrl || avatarImage}
+                    src={user?.avatarUrl || DEFAULT_AVATAR_URL}
                     alt="User avatar"
+                    onError={handleAvatarLoadError}
                     className="w-12 h-12 rounded-full border-2 border-border object-cover"
                   />
                   <div className="overflow-hidden">

--- a/frontend/src/components/JudgementPopup.tsx
+++ b/frontend/src/components/JudgementPopup.tsx
@@ -128,10 +128,10 @@ const JudgmentPopup: React.FC<JudgmentPopupProps> = ({
 
   const localAvatar =
     localStorage.getItem('userAvatar') ||
-    'https://avatar.iran.liara.run/public/40';
+    'https://api.dicebear.com/9.x/big-ears/svg?seed=Felix';
   const opponentAvatar =
     localStorage.getItem('opponentAvatar') ||
-    'https://avatar.iran.liara.run/public/31';
+    'https://api.dicebear.com/9.x/big-ears/svg?seed=Nolan';
 
 const isUserBotFormat = 'user' in judgment.opening_statement;
 

--- a/frontend/src/components/TeamChatSidebar.tsx
+++ b/frontend/src/components/TeamChatSidebar.tsx
@@ -156,7 +156,7 @@ const TeamChatSidebar: React.FC<TeamChatSidebarProps> = ({
               >
                 <Avatar className='w-8 h-8'>
                   <AvatarImage
-                    src={`https://avatar.iran.liara.run/public/${msg.userId}`}
+                    src={`https://api.dicebear.com/9.x/big-ears/svg?seed=${encodeURIComponent(msg.userId)}`}
                   />
                   <AvatarFallback>{msg.displayName[0]}</AvatarFallback>
                 </Avatar>

--- a/frontend/src/constants/avatar.ts
+++ b/frontend/src/constants/avatar.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_AVATAR_URL =
+  "https://api.dicebear.com/9.x/big-ears/svg?seed=Jude";

--- a/frontend/src/context/authContext.tsx
+++ b/frontend/src/context/authContext.tsx
@@ -9,6 +9,7 @@ import { useNavigate } from 'react-router-dom';
 import { useSetAtom } from 'jotai';
 import { userAtom } from '@/state/userAtom';
 import type { User } from '@/types/user';
+import { DEFAULT_AVATAR_URL } from '@/constants/avatar';
 
 const baseURL = import.meta.env.VITE_BASE_URL;
 const USER_CACHE_KEY = 'userProfile';
@@ -90,7 +91,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
           lastRatingUpdate:
             userData.lastRatingUpdate || new Date().toISOString(),
           avatarUrl:
-            userData.avatarUrl || 'https://avatar.iran.liara.run/public/10',
+            userData.avatarUrl || DEFAULT_AVATAR_URL,
           twitter: userData.twitter,
           instagram: userData.instagram,
           linkedin: userData.linkedin,
@@ -141,7 +142,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         lastRatingUpdate:
           data.user?.lastRatingUpdate || new Date().toISOString(),
         avatarUrl:
-          data.user?.avatarUrl || 'https://avatar.iran.liara.run/public/10',
+          data.user?.avatarUrl || DEFAULT_AVATAR_URL,
         twitter: data.user?.twitter || undefined,
         instagram: data.user?.instagram || undefined,
         linkedin: data.user?.linkedin || undefined,
@@ -214,7 +215,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
           rd: data.user?.rd || 350,
           volatility: data.user?.volatility || 0.06,
           lastRatingUpdate: data.user?.lastRatingUpdate || new Date().toISOString(),
-          avatarUrl: data.user?.avatarUrl || 'https://avatar.iran.liara.run/public/10',
+          avatarUrl: data.user?.avatarUrl || DEFAULT_AVATAR_URL,
           twitter: data.user?.twitter || undefined,
           instagram: data.user?.instagram || undefined,
           linkedin: data.user?.linkedin || undefined,
@@ -307,7 +308,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         lastRatingUpdate:
           data.user?.lastRatingUpdate || new Date().toISOString(),
         avatarUrl:
-          data.user?.avatarUrl || 'https://avatar.iran.liara.run/public/10',
+          data.user?.avatarUrl || DEFAULT_AVATAR_URL,
         twitter: data.user?.twitter || undefined,
         instagram: data.user?.instagram || undefined,
         linkedin: data.user?.linkedin || undefined,

--- a/frontend/src/hooks/useUser.ts
+++ b/frontend/src/hooks/useUser.ts
@@ -2,9 +2,9 @@ import { useEffect, useContext } from "react";
 import { useAtom } from "jotai";
 import { userAtom } from "../state/userAtom";
 import { AuthContext } from "../context/authContext";
+import { DEFAULT_AVATAR_URL } from "@/constants/avatar";
 
 const USER_CACHE_KEY = "userProfile";
-const DEFAULT_AVATAR = "https://avatar.iran.liara.run/public/10";
 const DEFAULT_RATING = 1500;
 const DEFAULT_RD = 350;
 const DEFAULT_VOLATILITY = 0.06;
@@ -73,7 +73,7 @@ export const useUser = () => {
           avatarUrl:
             profile.avatarUrl ||
             userData.avatarUrl ||
-            DEFAULT_AVATAR,
+            DEFAULT_AVATAR_URL,
           twitter: profile.twitter || userData.twitter,
           instagram: profile.instagram || userData.instagram,
           linkedin: profile.linkedin || userData.linkedin,


### PR DESCRIPTION
### Addressed Issues:

Fixes #389


### Screenshots/Recordings:

https://github.com/user-attachments/assets/270f66e2-1761-4254-a4e4-78cda2dae90f



#### Before

<img width="1565" height="815" alt="image" src="https://github.com/user-attachments/assets/13bdc247-479a-414a-adda-742f33581600" />


#### After

<img width="1651" height="714" alt="image" src="https://github.com/user-attachments/assets/6311c7e5-e0a4-4b26-a3a5-8f69b3522d2d" />


### Additional Notes:

This PR fixes broken default avatars caused by unavailable `avatar.iran.liara.run` URLs.

Changes include:

- Replaced broken default avatar URLs with DiceBear avatars.
- Added a shared frontend `DEFAULT_AVATAR_URL` constant.
- Added image-loading fallback handling to the Profile and header avatars.
- Added a local avatar fallback if the DiceBear image also fails.
- Updated avatar defaults used in debate rooms, team chat, authentication, and WebSocket flows.
- New email signups now receive a working default avatar.

Existing avatar values in MongoDB are not modified. If an existing avatar URL cannot be loaded, the UI displays the default avatar instead.

Validation performed:

- `go test ./controllers ./websocket ./cmd/server` passes.
- `git diff --check` passes.
- No remaining `avatar.iran.liara.run` references were found.
- The frontend production build is currently blocked by pre-existing TypeScript errors unrelated to this change.


### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: OpenAI Codex


## Checklist

- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions.
- [x] If applicable, I have made corresponding changes or additions to the documentation. *(Not applicable for this bug fix.)*
- [ ] If applicable, I have made corresponding changes or additions to tests. *(No automated frontend avatar tests currently exist.)*
- [x] My changes generate no new warnings or errors.
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there.
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md).
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced consistent DiceBear Big Ears avatars across profiles, debates, chat, teams, and authentication flows.
  - Added distinct seeded avatars for users and opponents where applicable.

- **Bug Fixes**
  - Improved avatar reliability with automatic fallback handling when images fail to load.
  - Standardized default avatar behavior across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->