### PR TITLE
Real-time synchronization in online debate rooms

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -77,6 +77,9 @@ func LoadConfig(path string) (*Config, error) {
 	if envDB := os.Getenv("DATABASE_URI"); envDB != "" {
 		cfg.Database.URI = envDB
 	}
+	if envRedisAddr := os.Getenv("REDIS_ADDR"); envRedisAddr != "" {
+		cfg.Redis.Addr = envRedisAddr
+	}
 	if envGemini := os.Getenv("GEMINI_API_KEY"); envGemini != "" {
 		cfg.Gemini.ApiKey = envGemini
 	}

--- a/backend/websocket/websocket.go
+++ b/backend/websocket/websocket.go
@@ -50,6 +50,7 @@ type Client struct {
 	LastActivity time.Time
 	IsMuted      bool   // New field to track mute status
 	Role         string // New field to track debate role (for/against)
+	Ready        bool   // Whether the debater is ready to start
 	SpeechText   string // New field to store speech text
 	ConnectionID string
 }
@@ -173,6 +174,7 @@ func buildParticipantsMessage(room *Room) map[string]interface{} {
 			"displayName": client.Username,
 			"email":       client.Email,
 			"role":        client.Role,
+			"ready":       client.Ready,
 			"isMuted":     client.IsMuted,
 		})
 	}
@@ -666,13 +668,14 @@ func handleTopicChange(room *Room, conn *websocket.Conn, message Message, roomID
 func handleRoleSelection(room *Room, conn *websocket.Conn, message Message, roomID string) {
 	// Store the role in the client
 	room.Mutex.Lock()
-	defer room.Mutex.Unlock()
 	if client, exists := room.Clients[conn]; exists {
 		if client.IsSpectator {
+			room.Mutex.Unlock()
 			return
 		}
 		client.Role = message.Role
 	}
+	room.Mutex.Unlock()
 
 	// Broadcast role selection to other clients
 	for _, r := range snapshotRecipients(room, conn) {
@@ -686,11 +689,28 @@ func handleRoleSelection(room *Room, conn *websocket.Conn, message Message, room
 
 // handleReadyStatus handles ready status
 func handleReadyStatus(room *Room, conn *websocket.Conn, message Message, roomID string) {
+	if message.Ready == nil {
+		return
+	}
+
+	room.Mutex.Lock()
+	client, exists := room.Clients[conn]
+	if !exists || client.IsSpectator {
+		room.Mutex.Unlock()
+		return
+	}
+	client.Ready = *message.Ready
+	message.UserID = client.UserID
+	room.Mutex.Unlock()
+
 	// Broadcast ready status to other clients
 	for _, r := range snapshotRecipients(room, conn) {
 		if err := r.SafeWriteJSON(message); err != nil {
 		}
 	}
+
+	// Reconnecting clients recover readiness from the participant snapshot.
+	broadcastParticipants(room)
 }
 
 // handleMuteRequest handles mute requests

--- a/backend/websocket/websocket_test.go
+++ b/backend/websocket/websocket_test.go
@@ -1,0 +1,39 @@
+package websocket
+
+import (
+	"testing"
+
+	gorilla "github.com/gorilla/websocket"
+)
+
+func TestBuildParticipantsMessageIncludesRecoverableRoomState(t *testing.T) {
+	conn := &gorilla.Conn{}
+	room := &Room{
+		Clients: map[*gorilla.Conn]*Client{
+			conn: {
+				UserID:   "user-1",
+				Username: "Alice",
+				Email:    "alice@example.com",
+				Role:     "for",
+				Ready:    true,
+			},
+		},
+	}
+
+	message := buildParticipantsMessage(room)
+	participants, ok := message["roomParticipants"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("roomParticipants has unexpected type %T", message["roomParticipants"])
+	}
+	if len(participants) != 1 {
+		t.Fatalf("expected one participant, got %d", len(participants))
+	}
+
+	participant := participants[0]
+	if ready, ok := participant["ready"].(bool); !ok || !ready {
+		t.Fatalf("expected ready=true, got %#v", participant["ready"])
+	}
+	if role, ok := participant["role"].(string); !ok || role != "for" {
+		t.Fatalf("expected role=for, got %#v", participant["role"])
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,16 @@ services:
       - ./backend:/app
     environment:
       - PORT=1313
+      - DATABASE_URI=mongodb://mongo:27017/debateai
       - CONFIG_PATH=./config/config.prod.yml
+      - REDIS_ADDR=redis:6379
     env_file:
       - ./backend/.env
     depends_on:
-      - mongo
+      mongo:
+        condition: service_started
+      redis:
+        condition: service_healthy
 
   frontend:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       - ./backend:/app
     environment:
       - PORT=1313
-      - DATABASE_URI=mongodb://mongo:27017/debateai
       - CONFIG_PATH=./config/config.prod.yml
     env_file:
       - ./backend/.env
@@ -37,5 +36,19 @@ services:
     volumes:
       - mongo_data:/data/db
 
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    command: ["redis-server", "--appendonly", "yes"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
 volumes:
   mongo_data:
+  redis_data:

--- a/frontend/src/Pages/OnlineDebateRoom.tsx
+++ b/frontend/src/Pages/OnlineDebateRoom.tsx
@@ -78,6 +78,8 @@ interface UserDetails {
   avatarUrl?: string;
   displayName?: string;
   email?: string;
+  role?: DebateRole;
+  ready?: boolean;
 }
 
 // Define WebSocket message structure
@@ -140,7 +142,7 @@ const BASE_URL = import.meta.env.VITE_BASE_URL || window.location.origin;
 
 const WS_BASE_URL = BASE_URL.replace(
   /^https?/,
-  (match) => (match === "https" ? "wss" : "ws")
+  (match: string) => (match === "https" ? "wss" : "ws")
 );
 
 
@@ -167,6 +169,7 @@ const OnlineDebateRoom = (): JSX.Element => {
   const [opponentUser, setOpponentUser] = useState<UserDetails | null>(null);
   const [roomParticipants, setRoomParticipants] = useState<UserDetails[]>([]);
   const [roomOwnerId, setRoomOwnerId] = useState<string | null>(null);
+  const [isWsConnected, setIsWsConnected] = useState(false);
 
   const isRoomOwner = Boolean(roomOwnerId && currentUserId === roomOwnerId);
 
@@ -183,7 +186,13 @@ const OnlineDebateRoom = (): JSX.Element => {
   const spectatorBaseIdRef = useRef<Map<string, Set<string>>>(new Map());
   const localStreamRef = useRef<MediaStream | null>(null);
   const localRoleRef = useRef<DebateRole | null>(null);
+  const peerRoleRef = useRef<DebateRole | null>(null);
+  const debatePhaseRef = useRef<DebatePhase>(DebatePhase.Setup);
   const currentUserIdRef = useRef<string | null>(currentUserId);
+  const currentUserRef = useRef(currentUser);
+  const fetchRoomParticipantsRef = useRef<
+    ((retryCount?: number, background?: boolean) => Promise<void>) | null
+  >(null);
   const localVideoRef = useRef<HTMLVideoElement>(null);
   const remoteVideoRef = useRef<HTMLVideoElement>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
@@ -294,8 +303,17 @@ const OnlineDebateRoom = (): JSX.Element => {
   }, [localRole]);
 
   useEffect(() => {
+    peerRoleRef.current = peerRole;
+  }, [peerRole]);
+
+  useEffect(() => {
+    debatePhaseRef.current = debatePhase;
+  }, [debatePhase]);
+
+  useEffect(() => {
     currentUserIdRef.current = currentUserId;
-  }, [currentUserId]);
+    currentUserRef.current = currentUser;
+  }, [currentUser, currentUserId]);
 
   const startSpectatorOffer = useCallback(
     async (baseConnectionId: string, requestId?: string) => {
@@ -376,7 +394,7 @@ const OnlineDebateRoom = (): JSX.Element => {
             role,
           })
         );
-      } catch (error) {
+      } catch {
         cleanupSpectatorConnection(connectionId);
       }
     },
@@ -920,10 +938,12 @@ const OnlineDebateRoom = (): JSX.Element => {
 
   // Function to fetch room participants
   const fetchRoomParticipants = useCallback(
-    async (retryCount = 0) => {
+    async (retryCount = 0, background = false) => {
       if (!roomId) return;
 
-      setIsLoading(true);
+      if (!background) {
+        setIsLoading(true);
+      }
       try {
         const token = getAuthToken();
         const response = await fetch(
@@ -1051,7 +1071,7 @@ const OnlineDebateRoom = (): JSX.Element => {
             }
 
             setTimeout(() => {
-              fetchRoomParticipants(retryCount + 1);
+              fetchRoomParticipants(retryCount + 1, background);
             }, 2000);
             return;
           }
@@ -1090,7 +1110,9 @@ const OnlineDebateRoom = (): JSX.Element => {
           setRoomOwnerId((prev) => prev ?? currentUser.id ?? null);
         }
       } finally {
-        setIsLoading(false);
+        if (!background) {
+          setIsLoading(false);
+        }
       }
     },
     [
@@ -1105,13 +1127,31 @@ const OnlineDebateRoom = (): JSX.Element => {
     ]
   );
 
+  useEffect(() => {
+    fetchRoomParticipantsRef.current = fetchRoomParticipants;
+  }, [fetchRoomParticipants]);
+
+  // A room join is persisted through HTTP, while the live notification is sent
+  // through WebSocket. Poll only while waiting so a missed socket event heals.
+  useEffect(() => {
+    if (!roomId || roomParticipants.length >= 2) return;
+
+    void fetchRoomParticipants(0, true);
+    const participantPoll = window.setInterval(() => {
+      void fetchRoomParticipants(0, true);
+    }, 3000);
+
+    return () => window.clearInterval(participantPoll);
+  }, [fetchRoomParticipants, roomId, roomParticipants.length]);
+
   // Initialize WebSocket, RTCPeerConnection, and media
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     const token = getAuthToken();
     if (!token || !roomId) return;
 
-   const wsUrl = `${WS_BASE_URL}/ws?room=${roomId}&token=${token}`;
+    let participantFetchTimeout: number | undefined;
+
+    const wsUrl = `${WS_BASE_URL}/ws?room=${roomId}&token=${token}`;
 
     const rws = new ReconnectingWebSocket(wsUrl, [], {
       connectionTimeout: 4000,
@@ -1123,13 +1163,22 @@ const OnlineDebateRoom = (): JSX.Element => {
     wsRef.current = rws;
 
     rws.onopen = () => {
+      setIsWsConnected(true);
       rws.send(JSON.stringify({ type: "join", room: roomId }));
       // Wait a bit before fetching participants to ensure room is fully created
-      setTimeout(() => {
-        fetchRoomParticipants();
+      participantFetchTimeout = window.setTimeout(() => {
+        void fetchRoomParticipantsRef.current?.();
       }, 1000);
       getMedia();
       flushSpectatorOfferQueue();
+    };
+
+    rws.onclose = () => {
+      setIsWsConnected(false);
+    };
+
+    rws.onerror = () => {
+      setIsWsConnected(false);
     };
 
     rws.onmessage = async (event) => {
@@ -1147,27 +1196,28 @@ const OnlineDebateRoom = (): JSX.Element => {
         case "phaseChange":
           if (data.phase) {
             console.debug(
-              `Received phase change to ${data.phase}. Local role: ${localRole}`
+              `Received phase change to ${data.phase}. Local role: ${localRoleRef.current}`
             );
             setDebatePhase(data.phase);
           }
           break;
         case "message":
-          if (data.message && peerRole) {
+          if (data.message && peerRoleRef.current) {
             // Store in speech transcripts for the current phase
             setSpeechTranscripts((prev) => ({
               ...prev,
-              [debatePhase]: (prev[debatePhase] || "") + " " + data.message,
+              [debatePhaseRef.current]:
+                (prev[debatePhaseRef.current] || "") + " " + data.message,
             }));
           }
           break;
         case "autoMuteStatus":
-          if (data.userId === currentUser?.id) {
+          if (data.userId === currentUserIdRef.current) {
             setIsAutoMuted(data.isMuted || false);
 
             // Automatically mute/unmute microphone based on turn
-            if (localStream) {
-              const audioTrack = localStream.getAudioTracks()[0];
+            if (localStreamRef.current) {
+              const audioTrack = localStreamRef.current.getAudioTracks()[0];
               if (audioTrack) {
                 audioTrack.enabled = !data.isMuted;
               }
@@ -1177,7 +1227,7 @@ const OnlineDebateRoom = (): JSX.Element => {
         case "speechText":
           if (data.userId && data.speechText) {
             // Store speech text in transcripts for the specified phase
-            const targetPhase = data.phase || debatePhase;
+            const targetPhase = data.phase || debatePhaseRef.current;
             setSpeechTranscripts((prev) => {
               const updated = {
                 ...prev,
@@ -1192,7 +1242,7 @@ const OnlineDebateRoom = (): JSX.Element => {
           if (
             data.userId &&
             data.liveTranscript &&
-            data.userId !== currentUser?.id
+            data.userId !== currentUserIdRef.current
           ) {
             // Only update if it's from the opponent
             setCurrentTranscript(data.liveTranscript);
@@ -1200,7 +1250,12 @@ const OnlineDebateRoom = (): JSX.Element => {
           break;
         case "userDetails":
           if (data.userDetails) {
-            if (data.userDetails.id === currentUser?.id) {
+            const activeUser = currentUserRef.current;
+            if (
+              data.userDetails.id === activeUser?.id ||
+              (data.userDetails.email &&
+                data.userDetails.email === activeUser?.email)
+            ) {
               setLocalUser(data.userDetails);
             } else {
               setOpponentUser(data.userDetails);
@@ -1215,35 +1270,42 @@ const OnlineDebateRoom = (): JSX.Element => {
             );
             setRoomParticipants(data.roomParticipants);
             // Update local and opponent user details when participants change
-            if (currentUser && data.roomParticipants.length >= 1) {
+            const activeUser = currentUserRef.current;
+            if (activeUser && data.roomParticipants.length >= 1) {
               const localParticipant = data.roomParticipants.find(
                 (p: UserDetails) =>
-                  p.id === currentUser.id || p.email === currentUser.email
+                  p.id === activeUser.id || p.email === activeUser.email
               );
               const opponentParticipant = data.roomParticipants.find(
                 (p: UserDetails) =>
-                  (p.id && p.id !== currentUser.id) ||
-                  (!p.id && p.email && p.email !== currentUser.email)
+                  (p.id && p.id !== activeUser.id) ||
+                  (!p.id && p.email && p.email !== activeUser.email)
               );
 
               if (localParticipant) {
                 setLocalUser({
                   ...localParticipant,
                   avatarUrl:
-                    currentUser.avatarUrl || localParticipant.avatarUrl,
+                    activeUser.avatarUrl || localParticipant.avatarUrl,
                   displayName:
-                    currentUser.displayName || localParticipant.displayName,
+                    activeUser.displayName || localParticipant.displayName,
                 });
+                if (localParticipant.ready !== undefined) {
+                  setLocalReady(localParticipant.ready);
+                }
+                if (localParticipant.role) {
+                  setLocalRole(localParticipant.role);
+                }
               } else {
                 // Fallback to current user data
                 setLocalUser({
-                  id: currentUser.id || "unknown",
+                  id: activeUser.id || "unknown",
                   username:
-                    currentUser.displayName || currentUser.email || "User",
+                    activeUser.displayName || activeUser.email || "User",
                   displayName:
-                    currentUser.displayName || currentUser.email || "User",
-                  elo: currentUser.rating || 1500,
-                  avatarUrl: currentUser.avatarUrl,
+                    activeUser.displayName || activeUser.email || "User",
+                  elo: activeUser.rating || 1500,
+                  avatarUrl: activeUser.avatarUrl,
                 });
               }
 
@@ -1254,8 +1316,16 @@ const OnlineDebateRoom = (): JSX.Element => {
                     opponentParticipant.avatarUrl ||
                     "https://api.dicebear.com/9.x/big-ears/svg?seed=Nolan",
                 });
+                if (opponentParticipant.ready !== undefined) {
+                  setPeerReady(opponentParticipant.ready);
+                }
+                if (opponentParticipant.role) {
+                  setPeerRole(opponentParticipant.role);
+                }
               } else {
                 setOpponentUser(null);
+                setPeerReady(false);
+                setPeerRole(null);
               }
             }
           }
@@ -1297,7 +1367,10 @@ const OnlineDebateRoom = (): JSX.Element => {
           }
           break;
         case "answer":
-          if (data.connectionId && data.targetUserId === currentUserId) {
+          if (
+            data.connectionId &&
+            data.targetUserId === currentUserIdRef.current
+          ) {
             const spectatorPc = data.connectionId
               ? spectatorPCsRef.current.get(data.connectionId)
               : null;
@@ -1311,7 +1384,9 @@ const OnlineDebateRoom = (): JSX.Element => {
                   for (const candidate of pending) {
                     try {
                       await spectatorPc.addIceCandidate(candidate);
-                    } catch (err) {}
+                    } catch {
+                      // Ignore candidates that became invalid during reconnect.
+                    }
                   }
                   spectatorPendingCandidatesRef.current.delete(
                     data.connectionId
@@ -1324,7 +1399,7 @@ const OnlineDebateRoom = (): JSX.Element => {
           } else if (
             data.connectionId &&
             data.targetUserId &&
-            data.targetUserId !== currentUserId
+            data.targetUserId !== currentUserIdRef.current
           ) {
             // Spectator answer meant for the other debater; ignore.
           } else if (pcRef.current && data.answer) {
@@ -1333,7 +1408,7 @@ const OnlineDebateRoom = (): JSX.Element => {
           break;
         case "candidate":
           if (data.connectionId) {
-            if (data.userId && data.userId !== currentUserId) {
+            if (data.userId && data.userId !== currentUserIdRef.current) {
               // Candidate is intended for the other debater's copy of this spectator connection.
               break;
             }
@@ -1356,10 +1431,9 @@ const OnlineDebateRoom = (): JSX.Element => {
                     queue
                   );
                 }
-              } catch (err) {
+              } catch {
                 cleanupSpectatorConnection(data.connectionId);
               }
-            } else if (!spectatorPc) {
             }
           } else if (pcRef.current && data.candidate) {
             await pcRef.current.addIceCandidate(data.candidate);
@@ -1403,6 +1477,9 @@ const OnlineDebateRoom = (): JSX.Element => {
     };
 
     return () => {
+      if (participantFetchTimeout !== undefined) {
+        window.clearTimeout(participantFetchTimeout);
+      }
       const activeLocalStream = localStreamRef.current;
       if (activeLocalStream) {
         activeLocalStream.getTracks().forEach((track) => track.stop());
@@ -1420,6 +1497,7 @@ const OnlineDebateRoom = (): JSX.Element => {
     };
   }, [
     cleanupSpectatorConnection,
+    cleanupSpectatorConnectionsByBase,
     flushSpectatorOfferQueue,
     processSpectatorOfferRequest,
     queueSpectatorOffer,
@@ -1999,11 +2077,17 @@ const OnlineDebateRoom = (): JSX.Element => {
   };
 
   const toggleReady = () => {
+    const socket = wsRef.current;
+    if (!isWsConnected || !socket || socket.readyState !== WebSocket.OPEN) {
+      window.alert(
+        "The room connection is still reconnecting. Please try again."
+      );
+      return;
+    }
+
     const newReadyState = !localReady;
+    socket.send(JSON.stringify({ type: "ready", ready: newReadyState }));
     setLocalReady(newReadyState);
-    wsRef.current?.send(
-      JSON.stringify({ type: "ready", ready: newReadyState })
-    );
   };
 
   // Manage setup popup visibility
@@ -2287,13 +2371,18 @@ const OnlineDebateRoom = (): JSX.Element => {
                 <div>
                   <Button
                     onClick={toggleReady}
+                    disabled={!isWsConnected}
                     className={`w-full py-2 rounded-lg transition ${
                       localReady
                         ? "bg-destructive text-destructive-foreground"
                         : "bg-accent text-accent-foreground"
                     }`}
                   >
-                    {localReady ? "Cancel Ready" : "I'm Ready"}
+                    {!isWsConnected
+                      ? "Connecting..."
+                      : localReady
+                      ? "Cancel Ready"
+                      : "I'm Ready"}
                   </Button>
                 </div>
               </>

--- a/frontend/src/components/DebatePopup.tsx
+++ b/frontend/src/components/DebatePopup.tsx
@@ -16,11 +16,42 @@ const DebatePopup: React.FC<DebatePopupProps> = ({ onClose }) => {
   );
 
   // Handler to join a debate room by sending the room code via navigation.
-  const handleJoinRoom = () => {
-    if (roomCode.trim() === '') return;
-    navigate(`/debate-room/${roomCode}`);
+const handleJoinRoom = async () => {
+  const trimmedRoomCode = roomCode.trim();
+  if (!trimmedRoomCode) return;
+
+  const token = localStorage.getItem("token");
+  if (!token) {
+    alert("Please sign in again.");
+    return;
+  }
+
+  const baseURL =
+    import.meta.env.VITE_BASE_URL || "http://localhost:1313";
+
+  try {
+    const response = await fetch(
+      `${baseURL}/rooms/${encodeURIComponent(trimmedRoomCode)}/join`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => null);
+      alert(data?.error || "Unable to join this room.");
+      return;
+    }
+
+    navigate(`/debate-room/${trimmedRoomCode}`);
     onClose();
-  };
+  } catch {
+    alert("Unable to connect to the server.");
+  }
+};
 
   // Handler to create a new room by sending a POST request to the backend.
   const handleCreateRoom = async () => {

--- a/frontend/src/components/DebatePopup.tsx
+++ b/frontend/src/components/DebatePopup.tsx
@@ -16,42 +16,42 @@ const DebatePopup: React.FC<DebatePopupProps> = ({ onClose }) => {
   );
 
   // Handler to join a debate room by sending the room code via navigation.
-const handleJoinRoom = async () => {
-  const trimmedRoomCode = roomCode.trim();
-  if (!trimmedRoomCode) return;
+  const handleJoinRoom = async () => {
+    const trimmedRoomCode = roomCode.trim();
+    if (!trimmedRoomCode) return;
 
-  const token = localStorage.getItem("token");
-  if (!token) {
-    alert("Please sign in again.");
-    return;
-  }
-
-  const baseURL =
-    import.meta.env.VITE_BASE_URL || "http://localhost:1313";
-
-  try {
-    const response = await fetch(
-      `${baseURL}/rooms/${encodeURIComponent(trimmedRoomCode)}/join`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    );
-
-    if (!response.ok) {
-      const data = await response.json().catch(() => null);
-      alert(data?.error || "Unable to join this room.");
+    const token = localStorage.getItem('token');
+    if (!token) {
+      alert('Please sign in again.');
       return;
     }
 
-    navigate(`/debate-room/${trimmedRoomCode}`);
-    onClose();
-  } catch {
-    alert("Unable to connect to the server.");
-  }
-};
+    const baseURL =
+      import.meta.env.VITE_BASE_URL || 'http://localhost:1313';
+
+    try {
+      const response = await fetch(
+        `${baseURL}/rooms/${encodeURIComponent(trimmedRoomCode)}/join`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        alert(data?.error || 'Unable to join this room.');
+        return;
+      }
+
+      navigate(`/debate-room/${trimmedRoomCode}`);
+      onClose();
+    } catch {
+      alert('Unable to connect to the server.');
+    }
+  };
 
   // Handler to create a new room by sending a POST request to the backend.
   const handleCreateRoom = async () => {
@@ -75,7 +75,7 @@ const handleJoinRoom = async () => {
       const room = await response.json();
       navigate(`/debate-room/${room.id}`);
       onClose();
-    } catch (error) {
+    } catch {
       alert('Error creating room.');
     }
   };


### PR DESCRIPTION
### Addressed Issues:

Fixes #405 

This PR fixes real-time synchronization in online debate rooms:

- Ensures an opponent appears after joining.
- Synchronizes role and ready-state changes.
- Fixes a room mutex deadlock triggered by role selection.
- Recovers participant, role, and ready state after reconnecting.
- Adds participant polling while waiting for an opponent.
- Prevents Ready actions while the WebSocket is disconnected.
- Correctly configures MongoDB and Redis networking in Docker Compose.


### Screenshots/Recordings:

https://github.com/user-attachments/assets/b3aa5669-7b4d-456d-a0b0-e3849bfe3733



### Additional Notes:

The backend now stores Ready state for connected participants and includes it in participant snapshots. This allows clients to recover the latest room state after missing an event or reconnecting.

Docker Compose now uses:

- `mongodb://mongo:27017/debateai` for MongoDB
- `redis:6379` for Redis

Verification performed:

- `go test ./websocket` passes.
- ESLint passes for `DebatePopup.tsx`.
- The modified room page has no ESLint errors.
- `git diff --check` passes.
- Backend successfully connects to MongoDB and Redis through Docker Compose.

The repository-wide frontend and Go builds currently report existing failures in unrelated files, including `CommentTree.tsx`, `Game.tsx`, `TeamDebateRoom.tsx`, `test_server.go`, and `debatevsbot.go`.


### AI Usage Disclosure:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools:

- OpenAI Codex (GPT-5) for repository analysis, debugging assistance, implementation suggestions, and test guidance.


## Checklist

- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions.
- [x] Documentation changes are not applicable to this bug fix.
- [x] I have made corresponding additions to tests.
- [x] My changes generate no new warnings or errors.
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there.
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md).
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Participants can mark themselves as ready, with readiness and roles visible in room updates.
  - Debate rooms now provide clearer connection status and reconnect behavior.
  - Room joining validates credentials and confirms success before navigation.

- **Bug Fixes**
  - Improved synchronization of participant roles and readiness.
  - Prevented invalid connection updates from affecting active rooms.
  - Improved room startup reliability and service connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->