### PR TITLE
Fix: Room creation failing due to hardcoded database name and missing type assertion

### DIFF
--- a/backend/routes/rooms.go
+++ b/backend/routes/rooms.go
@@ -61,9 +61,15 @@ func CreateRoomHandler(c *gin.Context) {
 	}
 
 	// Query user document using email
-	userCollection := db.MongoClient.Database("DebateAI").Collection("users")
+	userCollection := db.MongoDatabase.Collection("users")
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+
+	emailStr, ok := email.(string)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid email format"})
+		return
+	}
 
 	var user struct {
 		ID          primitive.ObjectID `bson:"_id"`
@@ -73,7 +79,7 @@ func CreateRoomHandler(c *gin.Context) {
 		AvatarURL   string             `bson:"avatarUrl"`
 	}
 
-	err := userCollection.FindOne(ctx, bson.M{"email": email}).Decode(&user)
+	err := userCollection.FindOne(ctx, bson.M{"email": emailStr}).Decode(&user)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
 		return
@@ -96,7 +102,7 @@ func CreateRoomHandler(c *gin.Context) {
 		Participants: []Participant{creatorParticipant},
 	}
 
-	roomCollection := db.MongoClient.Database("DebateAI").Collection("rooms")
+	roomCollection := db.MongoDatabase.Collection("rooms")
 	_, err = roomCollection.InsertOne(ctx, newRoom)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create room"})
@@ -109,7 +115,7 @@ func CreateRoomHandler(c *gin.Context) {
 // GetRoomsHandler handles GET /rooms and returns all rooms.
 func GetRoomsHandler(c *gin.Context) {
 
-	collection := db.MongoClient.Database("DebateAI").Collection("rooms")
+	collection := db.MongoDatabase.Collection("rooms")
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -140,7 +146,7 @@ func JoinRoomHandler(c *gin.Context) {
 	}
 
 	// Query user document using email
-	userCollection := db.MongoClient.Database("DebateAI").Collection("users")
+	userCollection := db.MongoDatabase.Collection("users")
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -174,7 +180,7 @@ func JoinRoomHandler(c *gin.Context) {
 	}
 
 	// Use atomic operation to join room
-	roomCollection := db.MongoClient.Database("DebateAI").Collection("rooms")
+	roomCollection := db.MongoDatabase.Collection("rooms")
 	filter := bson.M{"_id": roomId}
 	update := bson.M{
 		"$addToSet": bson.M{"participants": participant},
@@ -206,8 +212,8 @@ func GetRoomParticipantsHandler(c *gin.Context) {
 	}
 
 	// Query room document
-	roomCollection := db.MongoClient.Database("DebateAI").Collection("rooms")
-	userCollection := db.MongoClient.Database("DebateAI").Collection("users")
+	roomCollection := db.MongoDatabase.Collection("rooms")
+	userCollection := db.MongoDatabase.Collection("users")
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 

--- a/backend/services/transcriptservice.go
+++ b/backend/services/transcriptservice.go
@@ -369,17 +369,15 @@ func extractTopicFromTranscripts(transcripts map[string]string) string {
 }
 
 func lookupRoomTopic(ctx context.Context, roomID string) string {
-	if db.MongoClient == nil {
+	if db.MongoClient == nil || db.MongoDatabase == nil {
 		return ""
 	}
 
-	database := db.MongoDatabase
-	
 	var room struct {
 		Topic        string `bson:"topic"`
 		CurrentTopic string `bson:"currentTopic"`
 	}
-	if err := database.Collection("rooms").FindOne(ctx, bson.M{"_id": roomID}).Decode(&room); err == nil {
+	if err := db.MongoDatabase.Collection("rooms").FindOne(ctx, bson.M{"_id": roomID}).Decode(&room); err == nil {
 		if topic := strings.TrimSpace(room.Topic); topic != "" {
 			return topic
 		}

--- a/backend/services/transcriptservice.go
+++ b/backend/services/transcriptservice.go
@@ -373,11 +373,8 @@ func lookupRoomTopic(ctx context.Context, roomID string) string {
 		return ""
 	}
 
-	var database = db.MongoDatabase
-	if database == nil {
-		database = db.MongoClient.Database("DebateAI")
-	}
-
+	database := db.MongoDatabase
+	
 	var room struct {
 		Topic        string `bson:"topic"`
 		CurrentTopic string `bson:"currentTopic"`


### PR DESCRIPTION
## Problem:

Clicking "Create Room" always failed with a 404 "User not found" error, 
even though I was properly logged in via Google and could see my correct 
profile data everywhere else in the app.

## Investigation

While debugging, I found two separate issues in `rooms.go`:

### Bug 1: Hardcoded database name

`CreateRoomHandler`, `JoinRoomHandler`, `GetRoomsHandler`, and 
`GetRoomParticipantsHandler` were all hardcoding the database name:

​```go
db.MongoClient.Database("DebateAI").Collection("users")
​```

But the actual database the app connects to is resolved dynamically from 
the MongoDB URI in config, via `extractDBName()` in `db/db.go` — and 
stored in the shared `db.MongoDatabase` variable, which every other part 
of the app (including the auth middleware) already correctly uses.

If your URI doesn't explicitly include a database name in its path (which 
is easy to miss when copying the connection string from Atlas), 
`extractDBName()` falls back to a database called `test`. Since `rooms.go` 
was hardcoded to always look inside a database literally named `DebateAI` 
instead, any contributor whose database isn't named exactly that will hit 
this same failure — not just mine.

I confirmed this directly in Atlas: my actual data lives in `test`, and 
no database named `DebateAI` exists in my cluster at all.

**Fix:** replaced every hardcoded `db.MongoClient.Database("DebateAI")` 
with `db.MongoDatabase`, matching the pattern already used correctly 
elsewhere in the codebase.

### Bug 2: Missing type assertion in CreateRoomHandler

`JoinRoomHandler` and `GetRoomParticipantsHandler` both correctly convert 
the email pulled from the request context into a string before using it:

​```go
emailStr, ok := email.(string)
if !ok {
    c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid email format"})
    return
}
​```

`CreateRoomHandler` skipped this step and used the raw, untyped value 
directly in the query. This likely wasn't the direct cause of the 404 
(Bug 1 was), but it's a real inconsistency — and without the type check, 
there's no graceful handling if `c.Get("email")` ever returns something 
unexpected.

**Fix:** added the same type assertion `CreateRoomHandler` was missing, 
for consistency and safety with the rest of the file.

**BEFORE :**

https://github.com/user-attachments/assets/1fe54c4f-3be3-48e5-b156-a3cf0eed77f0

**AFTER :**

https://github.com/user-attachments/assets/4548544e-2e62-4374-bd30-9a31160a36b0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved room creation reliability by validating account email information before processing requests.
  * Updated room and transcript operations to use the application’s configured database connection, helping ensure consistent access to room, account, and topic data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->