### PR TITLE
Fix: Update deprecated Gemini model and  error logging for silent bot response failures.

### DIFF
--- a/backend/services/debatevsbot.go
+++ b/backend/services/debatevsbot.go
@@ -279,6 +279,7 @@ func GenerateBotResponse(botName, botLevel, topic string, history []models.Messa
 	ctx := context.Background()
 	response, err := generateDefaultModelText(ctx, prompt)
 	if err != nil {
+		log.Printf("❌ Gemini error in GenerateBotResponse: %v", err)
 		return personalityErrorResponse(botName, "A glitch in my logic, there is.")
 	}
 	if response == "" {

--- a/backend/services/gemini.go
+++ b/backend/services/gemini.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/genai"
 )
 
-const defaultGeminiModel = "gemini-2.5-flash"
+const defaultGeminiModel = "gemini-3.6-flash"
 
 func initGemini(apiKey string) (*genai.Client, error) {
 	config := &genai.ClientConfig{}


### PR DESCRIPTION
## Problem

Vs-bot debate responses and judging were failing silently, returning generic personality-flavored fallback messages instead of real AI-generated responses — even with a valid and correctly configured Gemini API key.

There were **two separate issues** contributing to the problem.

---

## Root Cause

### 1. Gemini errors were silently swallowed

`GenerateBotResponse` discarded the actual Gemini error and returned a hardcoded, in-character fallback message instead.

For example, when the **Rookie Rick** bot's Gemini request failed, the user would receive:

```text
Uh, wait a sec! Like, I totally blanked out, you know? My bad, kinda like that time at Cousin Joey's BBQ!
```

This fallback is defined per bot in `personalityErrorResponse`:

```go
case "Rookie Rick":
    return fmt.Sprintf(
        "%s Like, I totally blanked out, you know? My bad, kinda like that time at Cousin Joey's BBQ!",
        catchphrase,
    )
```

The issue was inconsistent with `JudgeDebate` in the same file, which already logs Gemini errors:

```go
// JudgeDebate — logs the error
if err != nil {
    log.Printf("Gemini error: %v", err)
}
```

Whereas `GenerateBotResponse` previously did this:

```go
// GenerateBotResponse — error was not logged
if err != nil {
    return personalityErrorResponse(botName, "A glitch in my logic, there is.")
}
```

As a result, the underlying Gemini failure was completely invisible in the server logs.

Every request still returned a `200 OK` with a plausible-looking, in-character response, making the failure appear to be normal application behavior.

The actual error only became visible after temporary debug logging was added to `GenerateBotResponse`.

---

### 2. Deprecated Gemini model

Once the underlying error was exposed, the actual failure was identified as a **404 from Google**:

```text
Error 404: This model models/gemini-2.5-flash is no longer available to
new users. Please update your code to use models/gemini-3.6-flash for
the latest features and improvements.
```
<img width="1223" height="554" alt="improper ai response" src="https://github.com/user-attachments/assets/618ec2e3-3013-4356-81be-b7500f62ec06" />


The project was using the hardcoded model:

```go
gemini-2.5-flash
```

This model is no longer available to new Gemini API keys, meaning new contributors setting up the project with a freshly created API key could encounter the same failure.

---

## Fix

Two changes were made:

### Error logging

Added error logging in case of failure for Gemini API errors in `GenerateBotResponse`

This brings `GenerateBotResponse` in line with the existing error-handling behavior in `JudgeDebate`.

### Gemini model update

Updated the default Gemini model:

```diff
- const defaultGeminiModel = "gemini-2.5-flash"
+ const defaultGeminiModel = "gemini-3.6-flash"
```

---

## NOTE: Needs Clarification for the Existing users with 2.5 version:

Google's error message specifically states that `gemini-2.5-flash` is **"no longer available to new users."**

This may imply that existing API keys or deployments could still be able to use the older model. I wasn't able to verify this independently because testing was performed with a newly created Gemini API key.

Therefore, if an existing deployment is currently relying on `gemini-2.5-flash`, this model change could potentially affect it as well.

This is being called out explicitly rather than assuming that existing users are unaffected.

---
## Before

Vs-bot returned generic personality-specific fallback messages instead of actual debate responses:

```text
"Uh, wait a sec! Like, I totally blanked out, you know?
My bad, kinda like that time at Cousin Joey's BBQ!"
```

The Gemini failure was also not visible in the server logs.


https://github.com/user-attachments/assets/1c9b10e0-3ada-4ec8-89bd-6c7901c1153f



---

### After

Vs-bot successfully returns contextual, AI-generated debate responses using the updated Gemini model.


https://github.com/user-attachments/assets/d00fa589-7a92-42a8-8c20-fb2c822aa86e




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error visibility when AI-generated debate responses fail.
  * Updated the default AI model used to generate responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->