### PR TITLE
Opponent video stream fix

### DIFF
--- a/backend/websocket/websocket.go
+++ b/backend/websocket/websocket.go
@@ -171,8 +171,11 @@ func buildParticipantsMessage(room *Room) map[string]interface{} {
 
 		participants = append(participants, map[string]interface{}{
 			"id":          client.UserID,
+			"username":    client.Username,
 			"displayName": client.Username,
 			"email":       client.Email,
+			"avatarUrl":   client.AvatarURL,
+			"elo":         client.Elo,
 			"role":        client.Role,
 			"ready":       client.Ready,
 			"isMuted":     client.IsMuted,

--- a/backend/websocket/websocket_test.go
+++ b/backend/websocket/websocket_test.go
@@ -11,11 +11,13 @@ func TestBuildParticipantsMessageIncludesRecoverableRoomState(t *testing.T) {
 	room := &Room{
 		Clients: map[*gorilla.Conn]*Client{
 			conn: {
-				UserID:   "user-1",
-				Username: "Alice",
-				Email:    "alice@example.com",
-				Role:     "for",
-				Ready:    true,
+				UserID:    "user-1",
+				Username:  "Alice",
+				Email:     "alice@example.com",
+				AvatarURL: "https://example.com/alice.png",
+				Elo:       1425,
+				Role:      "for",
+				Ready:     true,
 			},
 		},
 	}
@@ -35,5 +37,14 @@ func TestBuildParticipantsMessageIncludesRecoverableRoomState(t *testing.T) {
 	}
 	if role, ok := participant["role"].(string); !ok || role != "for" {
 		t.Fatalf("expected role=for, got %#v", participant["role"])
+	}
+	if username, ok := participant["username"].(string); !ok || username != "Alice" {
+		t.Fatalf("expected username=Alice, got %#v", participant["username"])
+	}
+	if avatarURL, ok := participant["avatarUrl"].(string); !ok || avatarURL != "https://example.com/alice.png" {
+		t.Fatalf("expected participant avatar URL, got %#v", participant["avatarUrl"])
+	}
+	if elo, ok := participant["elo"].(int); !ok || elo != 1425 {
+		t.Fatalf("expected elo=1425, got %#v", participant["elo"])
 	}
 }

--- a/frontend/src/Pages/OnlineDebateRoom.tsx
+++ b/frontend/src/Pages/OnlineDebateRoom.tsx
@@ -170,12 +170,14 @@ const OnlineDebateRoom = (): JSX.Element => {
   const [roomParticipants, setRoomParticipants] = useState<UserDetails[]>([]);
   const [roomOwnerId, setRoomOwnerId] = useState<string | null>(null);
   const [isWsConnected, setIsWsConnected] = useState(false);
+  const [isPeerWsConnected, setIsPeerWsConnected] = useState(false);
 
   const isRoomOwner = Boolean(roomOwnerId && currentUserId === roomOwnerId);
 
   // Refs for WebSocket, PeerConnection, and media elements
   const wsRef = useRef<ReconnectingWebSocket | null>(null);
   const pcRef = useRef<RTCPeerConnection | null>(null);
+  const peerOfferStartedRef = useRef(false);
   const spectatorPCsRef = useRef<Map<string, RTCPeerConnection>>(new Map());
   const spectatorOfferQueueRef = useRef<
     { connectionId: string; requestId?: string }[]
@@ -201,6 +203,7 @@ const OnlineDebateRoom = (): JSX.Element => {
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   const judgePollRef = useRef<NodeJS.Timeout | null>(null);
   const submissionStartedRef = useRef(false);
+  const debateEndedByConcessionRef = useRef(false);
 
   useEffect(() => {
     return () => {
@@ -816,15 +819,29 @@ const OnlineDebateRoom = (): JSX.Element => {
   ]);
 
   const handleConcede = useCallback(() => {
-    if (window.confirm("Are you sure you want to concede? This will count as a loss.")) {
-      if (wsRef.current) {
-        wsRef.current.send(JSON.stringify({
-          type: "concede",
-          room: roomId,
-          userId: currentUserId,
-          username: currentUser?.displayName || "User"
-        }));
+    if (
+      window.confirm(
+        "Are you sure you want to concede? This will count as a loss."
+      )
+    ) {
+      debateEndedByConcessionRef.current = true;
+      submissionStartedRef.current = true;
+      if (judgePollRef.current) {
+        clearInterval(judgePollRef.current);
+        judgePollRef.current = null;
       }
+
+      if (wsRef.current) {
+        wsRef.current.send(
+          JSON.stringify({
+            type: "concede",
+            room: roomId,
+            userId: currentUserId,
+            username: currentUser?.displayName || "User",
+          })
+        );
+      }
+      setShowJudgment(false);
       setDebatePhase(DebatePhase.Finished);
       setPopup({
         show: true,
@@ -1150,6 +1167,8 @@ const OnlineDebateRoom = (): JSX.Element => {
     if (!token || !roomId) return;
 
     let participantFetchTimeout: number | undefined;
+    let pendingPeerOffer: RTCSessionDescriptionInit | null = null;
+    const pendingPeerCandidates: RTCIceCandidateInit[] = [];
 
     const wsUrl = `${WS_BASE_URL}/ws?room=${roomId}&token=${token}`;
 
@@ -1175,10 +1194,35 @@ const OnlineDebateRoom = (): JSX.Element => {
 
     rws.onclose = () => {
       setIsWsConnected(false);
+      setIsPeerWsConnected(false);
     };
 
     rws.onerror = () => {
       setIsWsConnected(false);
+      setIsPeerWsConnected(false);
+    };
+
+    const flushPendingPeerCandidates = async () => {
+      const pc = pcRef.current;
+      if (!pc?.remoteDescription) return;
+
+      while (pendingPeerCandidates.length > 0) {
+        const candidate = pendingPeerCandidates.shift();
+        if (candidate) {
+          await pc.addIceCandidate(candidate);
+        }
+      }
+    };
+
+    const acceptPeerOffer = async (offer: RTCSessionDescriptionInit) => {
+      const pc = pcRef.current;
+      if (!pc) return;
+
+      await pc.setRemoteDescription(offer);
+      await flushPendingPeerCandidates();
+      const answer = await pc.createAnswer();
+      await pc.setLocalDescription(answer);
+      wsRef.current?.send(JSON.stringify({ type: "answer", answer }));
     };
 
     rws.onmessage = async (event) => {
@@ -1264,6 +1308,7 @@ const OnlineDebateRoom = (): JSX.Element => {
           break;
         case "roomParticipants":
           if (data.roomParticipants) {
+            setIsPeerWsConnected(data.roomParticipants.length >= 2);
             console.debug(
               "Received room participants update:",
               data.roomParticipants
@@ -1330,14 +1375,28 @@ const OnlineDebateRoom = (): JSX.Element => {
             }
           }
           break;
-        case "concede":
+        case "concede": {
+          debateEndedByConcessionRef.current = true;
+          submissionStartedRef.current = true;
+          if (judgePollRef.current) {
+            clearInterval(judgePollRef.current);
+            judgePollRef.current = null;
+          }
+
+          const localUserConceded = data.userId === currentUserIdRef.current;
+          setShowJudgment(false);
           setDebatePhase(DebatePhase.Finished);
           setPopup({
             show: true,
-            message: `${data.username || "Opponent"} has conceded the debate. You win!`,
+            message: localUserConceded
+              ? "You have conceded the debate."
+              : `${
+                  data.username || "Opponent"
+                } has conceded the debate. You win!`,
             isJudging: false,
           });
           break;
+        }
         case "spectatorJoined":
           if (data.spectator?.connectionId) {
             queueSpectatorOffer(
@@ -1360,10 +1419,11 @@ const OnlineDebateRoom = (): JSX.Element => {
             break;
           }
           if (pcRef.current && data.offer) {
-            await pcRef.current.setRemoteDescription(data.offer!);
-            const answer = await pcRef.current.createAnswer();
-            await pcRef.current.setLocalDescription(answer);
-            wsRef.current?.send(JSON.stringify({ type: "answer", answer }));
+            if (localStreamRef.current) {
+              await acceptPeerOffer(data.offer);
+            } else {
+              pendingPeerOffer = data.offer;
+            }
           }
           break;
         case "answer":
@@ -1404,6 +1464,7 @@ const OnlineDebateRoom = (): JSX.Element => {
             // Spectator answer meant for the other debater; ignore.
           } else if (pcRef.current && data.answer) {
             await pcRef.current.setRemoteDescription(data.answer);
+            await flushPendingPeerCandidates();
           }
           break;
         case "candidate":
@@ -1436,7 +1497,11 @@ const OnlineDebateRoom = (): JSX.Element => {
               }
             }
           } else if (pcRef.current && data.candidate) {
-            await pcRef.current.addIceCandidate(data.candidate);
+            if (pcRef.current.remoteDescription) {
+              await pcRef.current.addIceCandidate(data.candidate);
+            } else {
+              pendingPeerCandidates.push(data.candidate);
+            }
           }
           break;
       }
@@ -1465,8 +1530,14 @@ const OnlineDebateRoom = (): JSX.Element => {
           video: { width: 1280, height: 720 },
           audio: true,
         });
+        localStreamRef.current = stream;
         setLocalStream(stream);
         stream.getTracks().forEach((track) => pc.addTrack(track, stream));
+        if (pendingPeerOffer) {
+          const offer = pendingPeerOffer;
+          pendingPeerOffer = null;
+          await acceptPeerOffer(offer);
+        }
         flushSpectatorOfferQueue();
       } catch (err) {
         setMediaError(
@@ -1494,6 +1565,7 @@ const OnlineDebateRoom = (): JSX.Element => {
       spectatorPCsRef.current.clear();
       rws.close();
       pc.close();
+      peerOfferStartedRef.current = false;
     };
   }, [
     cleanupSpectatorConnection,
@@ -1503,6 +1575,45 @@ const OnlineDebateRoom = (): JSX.Element => {
     queueSpectatorOffer,
     roomId,
   ]);
+
+  const startPeerVideo = useCallback(async () => {
+    const pc = pcRef.current;
+    const ws = wsRef.current;
+
+    if (
+      !isRoomOwner ||
+      !isWsConnected ||
+      !isPeerWsConnected ||
+      !localStream ||
+      !pc ||
+      !ws ||
+      ws.readyState !== WebSocket.OPEN ||
+      pc.signalingState !== "stable" ||
+      peerOfferStartedRef.current
+    ) {
+      return;
+    }
+
+    peerOfferStartedRef.current = true;
+    try {
+      const offer = await pc.createOffer();
+      await pc.setLocalDescription(offer);
+      ws.send(JSON.stringify({ type: "offer", offer }));
+    } catch (error) {
+      peerOfferStartedRef.current = false;
+      console.error("Failed to start opponent video stream:", error);
+    }
+  }, [isPeerWsConnected, isRoomOwner, isWsConnected, localStream]);
+
+  useEffect(() => {
+    void startPeerVideo();
+  }, [startPeerVideo]);
+
+  useEffect(() => {
+    if (!isPeerWsConnected) {
+      peerOfferStartedRef.current = false;
+    }
+  }, [isPeerWsConnected]);
 
   useEffect(() => {
     flushSpectatorOfferQueue();
@@ -2042,15 +2153,20 @@ const OnlineDebateRoom = (): JSX.Element => {
 
   // Trigger logMessageHistory when debatePhase changes to Finished
   useEffect(() => {
-    if (debatePhase === DebatePhase.Finished && localRole) {
+    if (
+      debatePhase === DebatePhase.Finished &&
+      localRole &&
+      !debateEndedByConcessionRef.current
+    ) {
       logMessageHistory();
     }
   }, [debatePhase, localRole, logMessageHistory]);
 
-  // Reset submissionStartedRef whenever phase moves away from Finished.
+  // Reset terminal-flow guards whenever phase moves away from Finished.
   useEffect(() => {
     if (debatePhase !== DebatePhase.Finished) {
       submissionStartedRef.current = false;
+      debateEndedByConcessionRef.current = false;
     }
   }, [debatePhase]);
 
@@ -2113,16 +2229,6 @@ const OnlineDebateRoom = (): JSX.Element => {
       console.debug(
         `Countdown finished. Starting debate at ${DebatePhase.OpeningFor} for ${localRole}`
       );
-      if (localRole === "for") {
-        pcRef.current
-          ?.createOffer()
-          .then((offer) =>
-            pcRef.current!.setLocalDescription(offer).then(() => offer)
-          )
-          .then((offer) =>
-            wsRef.current?.send(JSON.stringify({ type: "offer", offer }))
-          );
-      }
     }
   }, [countdown, localRole]);
 

--- a/frontend/src/components/DebatePopup.tsx
+++ b/frontend/src/components/DebatePopup.tsx
@@ -8,6 +8,10 @@ interface DebatePopupProps {
   onClose: () => void;
 }
 
+const baseURL = (
+  import.meta.env.VITE_BASE_URL || 'http://localhost:1313'
+).replace(/\/+$/, '');
+
 const DebatePopup: React.FC<DebatePopupProps> = ({ onClose }) => {
   const navigate = useNavigate();
   const [roomCode, setRoomCode] = useState('');
@@ -25,9 +29,6 @@ const DebatePopup: React.FC<DebatePopupProps> = ({ onClose }) => {
       alert('Please sign in again.');
       return;
     }
-
-    const baseURL =
-      import.meta.env.VITE_BASE_URL || 'http://localhost:1313';
 
     try {
       const response = await fetch(
@@ -59,7 +60,7 @@ const DebatePopup: React.FC<DebatePopupProps> = ({ onClose }) => {
     try {
       // Sending a POST request to create a new room.
       // You might also send additional parameters (e.g., room type, settings).
-      const response = await fetch('http://localhost:1313/rooms', {
+      const response = await fetch(`${baseURL}/rooms`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/components/RoomBrowser.tsx
+++ b/frontend/src/components/RoomBrowser.tsx
@@ -13,6 +13,10 @@ interface Room {
   participants: Participant[] | null;
 }
 
+const baseURL = (
+  import.meta.env.VITE_BASE_URL || 'http://localhost:1313'
+).replace(/\/+$/, '');
+
 const RoomBrowser: React.FC = () => {
   const [rooms, setRooms] = useState<Room[]>([]);
   const [loading, setLoading] = useState(true);
@@ -21,7 +25,7 @@ const RoomBrowser: React.FC = () => {
   const fetchRooms = async () => {
     const token = localStorage.getItem('token');
     try {
-      const response = await fetch('http://localhost:1313/rooms', {
+      const response = await fetch(`${baseURL}/rooms`, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
@@ -45,7 +49,8 @@ const RoomBrowser: React.FC = () => {
       }));
 
       setRooms(normalizedRooms);
-    } catch (error) {
+    } catch {
+      setRooms([]);
     } finally {
       setLoading(false);
     }
@@ -60,22 +65,19 @@ const RoomBrowser: React.FC = () => {
   const handleJoinMatch = async (roomId: string) => {
     const token = localStorage.getItem('token');
     try {
-      const response = await fetch(
-        `http://localhost:1313/rooms/${roomId}/join`,
-        {
+      const response = await fetch(`${baseURL}/rooms/${roomId}/join`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${token}`,
           },
-        }
-      );
+        });
       if (!response.ok) {
         alert(`Failed to join room ${roomId}.`);
         return;
       }
       navigate(`/debate-room/${roomId}`);
-    } catch (error) {
+    } catch {
       alert('An error occurred while joining the match.');
     }
   };


### PR DESCRIPTION
### Addressed Issues:

Fixes #412


### Screenshots/Recordings:

Added before-and-after screenshots/recordings demonstrating:

- Before: Only the local camera stream was visible.
<img width="1041" height="601" alt="Image" src="https://github.com/user-attachments/assets/04d56c1c-27e9-445b-bbd2-c4b8acada6a6" />

- After: Both local and opponent video streams are displayed correctly.

https://github.com/user-attachments/assets/81490f82-d1a5-4990-99f7-e3a8bb44b5cb



### Additional Notes:

This PR fixes unreliable WebRTC negotiation in online debate rooms.

Key changes:

- Starts peer-video negotiation when both participants, the WebSocket connection, and the local media stream are ready.
- Removes the dependency on the debate countdown and the `"for"` role for creating an offer.
- Queues offers received before local media initialization.
- Queues ICE candidates received before the remote description is available.
- Resets negotiation state after a disconnection so users can reconnect.
- Uses the existing WebSocket connection for WebRTC signaling.

Tested manually using two different accounts on separate devices. Both users could see their local video and the opponent's live video.


### AI Usage Disclosure:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: OpenAI Codex (GPT-5)


## Checklist

- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions.
- [x] If applicable, I have made corresponding changes or additions to the documentation.
- [x] If applicable, I have made corresponding changes or additions to tests.
- [x] My changes generate no new warnings or errors.
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there.
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md).
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Participant information now includes usernames, avatar images, and Elo ratings.
  - Backend connection settings can be configured through the application environment.

- **Bug Fixes**
  - Improved peer video connection setup and signaling reliability.
  - Prevented duplicate connection offers and ensured queued connection updates are handled correctly.
  - Conceding a debate now properly stops related processing and prevents incorrect judgment submission.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->