### PR TITLE
fix(frontend): use configured backend URL for API and WebSocket requests

### DIFF
--- a/frontend/src/Pages/ProsConsChallenge.tsx
+++ b/frontend/src/Pages/ProsConsChallenge.tsx
@@ -16,6 +16,8 @@ interface Evaluation {
   score: number;
 }
 
+const baseURL = import.meta.env.VITE_BASE_URL || 'http://localhost:1313';
+
 const ProsConsChallenge: React.FC = () => {
   const [token, setToken] = useState<string | null>(null);
   const [topic, setTopic] = useState<string | null>(null);
@@ -41,7 +43,7 @@ const ProsConsChallenge: React.FC = () => {
     setIsLoading(true);
     setError(null);
     try {
-      const response = await fetch("http://localhost:1313/coach/pros-cons/topic", {
+      const response = await fetch(`${baseURL}/coach/pros-cons/topic`, {
         method: "GET",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -82,7 +84,7 @@ const ProsConsChallenge: React.FC = () => {
     setIsLoading(true);
     setError(null);
     try {
-      const response = await fetch("http://localhost:1313/coach/pros-cons/submit", {
+      const response = await fetch(`${baseURL}/coach/pros-cons/submit`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,

--- a/frontend/src/Pages/StrengthenArgument.tsx
+++ b/frontend/src/Pages/StrengthenArgument.tsx
@@ -17,6 +17,8 @@ import {
 } from "@/components/ui/dialog";
 import { getAuthToken } from "@/utils/auth";
 
+const baseURL = import.meta.env.VITE_BASE_URL || 'http://localhost:1313';
+
 // Dummy list of topics for suggestions
 const sampleTopics = [
   "Should AI rule the world?",
@@ -112,7 +114,7 @@ const StrengthenArgument: React.FC = () => {
     setError(null);
     setWeakStatement(null);
     try {
-      const url = `http://localhost:1313/coach/strengthen-argument/weak-statement?topic=${encodeURIComponent(topic)}&stance=${encodeURIComponent(stance)}`;
+      const url = `${baseURL}/coach/strengthen-argument/weak-statement?topic=${encodeURIComponent(topic)}&stance=${encodeURIComponent(stance)}`;
       const response = await fetch(url, {
         method: "GET",
         headers: {
@@ -152,7 +154,7 @@ const StrengthenArgument: React.FC = () => {
     setIsLoading(true);
     setError(null);
     try {
-      const response = await fetch("http://localhost:1313/coach/strengthen-argument/evaluate", {
+      const response = await fetch(`${baseURL}/coach/strengthen-argument/evaluate`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/frontend/src/components/ChatRoom.tsx
+++ b/frontend/src/components/ChatRoom.tsx
@@ -17,6 +17,10 @@ interface FloatingEmoji {
 
 type VoteOption = 'FOR' | 'AGAINST';
 
+const wsBaseURL = (
+  import.meta.env.VITE_BASE_URL || 'http://localhost:1313'
+).replace(/^http/, 'ws');
+
 const ChatRoom = () => {
   const { roomId } = useParams();
   const [username, setUsername] = useState('');
@@ -45,7 +49,7 @@ const ChatRoom = () => {
     if (!token) return;
 
     wsRef.current = new WebSocket(
-      `ws://localhost:1313/chat/${roomId}?token=${token}`
+      `${wsBaseURL}/chat/${roomId}?token=${token}`
     );
 
     wsRef.current.onopen = () => {

--- a/frontend/src/components/DebatePopup.tsx
+++ b/frontend/src/components/DebatePopup.tsx
@@ -8,6 +8,8 @@ interface DebatePopupProps {
   onClose: () => void;
 }
 
+const baseURL = import.meta.env.VITE_BASE_URL || 'http://localhost:1313';
+
 const DebatePopup: React.FC<DebatePopupProps> = ({ onClose }) => {
   const navigate = useNavigate();
   const [roomCode, setRoomCode] = useState('');
@@ -25,9 +27,6 @@ const DebatePopup: React.FC<DebatePopupProps> = ({ onClose }) => {
       alert('Please sign in again.');
       return;
     }
-
-    const baseURL =
-      import.meta.env.VITE_BASE_URL || 'http://localhost:1313';
 
     try {
       const response = await fetch(
@@ -59,7 +58,7 @@ const DebatePopup: React.FC<DebatePopupProps> = ({ onClose }) => {
     try {
       // Sending a POST request to create a new room.
       // You might also send additional parameters (e.g., room type, settings).
-      const response = await fetch('http://localhost:1313/rooms', {
+      const response = await fetch(`${baseURL}/rooms`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/components/Matchmaking.tsx
+++ b/frontend/src/components/Matchmaking.tsx
@@ -24,6 +24,10 @@ interface MatchmakingMessage {
   error?: string;
 }
 
+const wsBaseURL = (
+  import.meta.env.VITE_BASE_URL || 'http://localhost:1313'
+).replace(/^http/, 'ws');
+
 const Matchmaking: React.FC = () => {
   const [pool, setPool] = useState<MatchmakingPool[]>([]);
   const [isConnected, setIsConnected] = useState(false);
@@ -59,7 +63,7 @@ const Matchmaking: React.FC = () => {
 
     // Connect to WebSocket with authentication token
     const ws = new WebSocket(
-      `ws://localhost:1313/ws/matchmaking?token=${token}`
+      `${wsBaseURL}/ws/matchmaking?token=${token}`
     );
     wsRef.current = ws;
 

--- a/frontend/src/components/RoomBrowser.tsx
+++ b/frontend/src/components/RoomBrowser.tsx
@@ -13,6 +13,8 @@ interface Room {
   participants: Participant[] | null;
 }
 
+const baseURL = import.meta.env.VITE_BASE_URL || 'http://localhost:1313';
+
 const RoomBrowser: React.FC = () => {
   const [rooms, setRooms] = useState<Room[]>([]);
   const [loading, setLoading] = useState(true);
@@ -21,7 +23,7 @@ const RoomBrowser: React.FC = () => {
   const fetchRooms = async () => {
     const token = localStorage.getItem('token');
     try {
-      const response = await fetch('http://localhost:1313/rooms', {
+      const response = await fetch(`${baseURL}/rooms`, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
@@ -61,7 +63,7 @@ const RoomBrowser: React.FC = () => {
     const token = localStorage.getItem('token');
     try {
       const response = await fetch(
-        `http://localhost:1313/rooms/${roomId}/join`,
+        `${baseURL}/rooms/${roomId}/join`,
         {
           method: 'POST',
           headers: {


### PR DESCRIPTION
### Addressed Issues

Fixes #419

### Screenshots/Recordings

Not applicable. This PR changes backend URL configuration and does not introduce any visual interface changes.

### Additional Notes

Several frontend features were directly calling `http://localhost:1313` or `ws://localhost:1313`. These requests failed when the frontend was connected to a deployed backend.

This PR updates the affected functionality to use the configured Vite environment variable:

```ts
import.meta.env.VITE_BASE_URL || "http://localhost:1313"
```

The local URL remains available as a fallback for local development.

For WebSocket connections, the resolved backend URL is converted as follows:

- `http://` becomes `ws://`
- `https://` becomes `wss://`

The updated functionality includes:

- Creating debate rooms
- Listing available rooms
- Joining debate rooms
- Individual matchmaking
- Chat WebSocket connections
- Pros and Cons Challenge
- Strengthen Argument Challenge

No documentation or additional tests were required because this is a frontend configuration fix with no API contract or visual changes.

The repository currently contains some pre-existing TypeScript and ESLint errors unrelated to this PR. This change introduces no new URL-related errors or warnings.

### AI Usage Disclosure

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: OpenAI Codex (GPT-5)

## Checklist

- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions.
- [x] If applicable, I have made corresponding changes or additions to the documentation.
- [x] If applicable, I have made corresponding changes or additions to tests.
- [x] My changes generate no new warnings or errors.
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there.
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md).
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.