### PR TITLE
Fix: "Contribution Guide" button links to nonexistent file, causing 404 Error.

### DIFF
--- a/frontend/src/Pages/SupportOpenSource.tsx
+++ b/frontend/src/Pages/SupportOpenSource.tsx
@@ -114,7 +114,7 @@ const SupportOpenSource = () => {
             description="Join the developer community and help improve DebateAI with your technical skills."
             buttonText="Contribution Guide"
             hoverType="orange"
-            onClick={() => window.open('https://github.com/AOSSIE-Org/DebateAI/blob/master/CONTRIBUTING.md', '_blank')}
+            onClick={() => window.open('https://github.com/AOSSIE-Org/DebateAI/blob/main/README.md#contribution-guidelines', '_blank')}
           />
           <SupportCard 
             icon={<Bug className="w-6 h-6" />}


### PR DESCRIPTION
## Problem

Clicking the "Contribution Guide" button on the Support DebateAI page 
(`/support-os`) redirected to a broken link, showing a GitHub 404 page 
instead of the actual contribution guidelines.

## Root cause

The button linked to:
​```
https://github.com/AOSSIE-Org/DebateAI/blob/master/CONTRIBUTING.md
​```

This URL is broken for two separate reasons:
1. It points to the `master` branch, but the repository's default branch 
   is `main`
2. There is no standalone `CONTRIBUTING.md` file in the repo — the 
   contribution guidelines actually live as a section inside `README.md`

GitHub's redirect-on-missing-branch behavior masked the first issue 
(it auto-redirects `master` → `main`), but the second issue still 
resulted in a clear 404, since `CONTRIBUTING.md` doesn't exist at that 
path at all.

## Fix

Updated the link to point directly to the Contribution Guidelines 
section within `README.md`:
​```
https://github.com/AOSSIE-Org/DebateAI/blob/main/README.md#contribution-guidelines
​```

This correctly resolves to the `main` branch and jumps straight to the 
relevant section, rather than the top of the file.

## Testing

- Clicked "Contribution Guide" before the fix — confirmed it 404s
- Clicked it after the fix — confirmed it correctly opens `README.md` 
  scrolled to the Contribution Guidelines section

## Before / After

**BEFORE:**

https://github.com/user-attachments/assets/c529e8aa-0ce0-4c54-8f9c-07deb401489a


**AFTER:**

https://github.com/user-attachments/assets/c02cec16-c5f7-4b38-b3f7-7fd9fbfe9138



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “Contribute Code” support card to open the contribution guidelines in the repository’s current main-branch README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->