### PR TITLE
fix: make comments heading theme-aware in dark mode

### DIFF
--- a/frontend/src/components/CommentTree.tsx
+++ b/frontend/src/components/CommentTree.tsx
@@ -621,7 +621,7 @@ const CommentTree: React.FC<CommentTreeProps> = ({
   return (
     <div className={`comment-tree ${className}`}>
       <div className="mb-4">
-        <h3 className="text-lg font-semibold text-gray-900 mb-2">Comments</h3>
+        <h3 className="text-lg font-semibold text-foreground mb-2">Comments</h3>
         {error && (
           <div className="p-2 mb-2 bg-yellow-50 border border-yellow-200 rounded text-sm text-yellow-800">
             {error}


### PR DESCRIPTION
### Addressed Issues

Fixes #441

### Problem

The `Comments` heading in the Saved Debate Transcripts view used a fixed `text-gray-900` color, which made it appear too dark and difficult to read in dark mode.

### Changes

Updated the `Comments` heading in `frontend/src/components/CommentTree.tsx` to use the existing theme-aware `text-foreground` class.

This keeps the existing styling structure while allowing the heading color to adapt correctly to the active theme.

### Testing

- Verified the `Comments` heading in light mode.
- Verified the `Comments` heading in dark mode.
- Confirmed the heading remains readable in both themes.
- Confirmed no unrelated files were changed.

### Manual Verification

1. Open the Saved Debate Transcripts section.
2. Open a transcript that contains comments.
3. Check the `Comments` heading in light mode.
4. Switch to dark mode.
5. Verify that the `Comments` heading changes to the appropriate theme-aware color and remains clearly readable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the comments heading color to better match the app’s foreground text styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->