### PR TITLE
fix: make team builder heading theme-aware

### DIFF
--- a/frontend/src/Pages/TeamBuilder.tsx
+++ b/frontend/src/Pages/TeamBuilder.tsx
@@ -335,7 +335,7 @@ const TeamBuilder: React.FC = () => {
   return (
     <div className="container mx-auto p-6 max-w-6xl">
       <div className="mb-6">
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">Team Builder</h1>
+        <h1 className="text-3xl font-bold text-foreground mb-2">Team Builder</h1>
         <p className="text-gray-600">
           Create or join a team to participate in team debates
         </p>


### PR DESCRIPTION
### Addressed Issues:

Fixes #443 

### Changes:

Updated the `Team Builder` heading in `frontend/src/Pages/TeamBuilder.tsx` to use the existing theme-aware `text-foreground` class instead of the fixed `text-gray-900` color.

This ensures the heading adapts correctly when Dark Theme is enabled while preserving the existing styling and layout.

### Screenshots/Recordings:

Before:
- Team Builder heading remained dark/black in Dark Theme.
<img width="1241" height="348" alt="Screenshot 2026-09-03 200224" src="https://github.com/user-attachments/assets/7e2e766f-0430-48e0-b873-44668e925cc3" />




After:
- Team Builder heading correctly adapts to the active theme.
<img width="1481" height="396" alt="image" src="https://github.com/user-attachments/assets/7bc236e9-b9a3-4fea-9dd2-bd5a348a25c1" />


### Additional Notes:

### Testing:
- Verified the Team Builder page in Light Theme.
- Verified the Team Builder page in Dark Theme.
- Confirmed the heading remains readable in both themes.
- Confirmed no unrelated files were changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Team Builder page heading to use a theme-aware text color, improving readability across active themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->