### PR TITLE
fix(websocket): prevent debater race condition

### DIFF
--- a/backend/websocket/websocket.go
+++ b/backend/websocket/websocket.go
@@ -143,6 +143,8 @@ func countDebaters(room *Room) int {
 	}
 	return count
 }
+
+// tryAddClient atomically checks the debater limit and adds the client to the room.
 func tryAddClient(room *Room, conn *websocket.Conn, client *Client) bool {
 	room.Mutex.Lock()
 	defer room.Mutex.Unlock()

--- a/backend/websocket/websocket.go
+++ b/backend/websocket/websocket.go
@@ -143,7 +143,26 @@ func countDebaters(room *Room) int {
 	}
 	return count
 }
+func tryAddClient(room *Room, conn *websocket.Conn, client *Client) bool {
+	room.Mutex.Lock()
+	defer room.Mutex.Unlock()
 
+	if !client.IsSpectator {
+		currentDebaters := 0
+		for _, existing := range room.Clients {
+			if !existing.IsSpectator {
+				currentDebaters++
+			}
+		}
+
+		if currentDebaters >= 2 {
+			return false
+		}
+	}
+
+	room.Clients[conn] = client
+	return true
+}
 func countSpectators(room *Room) int {
 	room.Mutex.Lock()
 	defer room.Mutex.Unlock()
@@ -283,24 +302,9 @@ func WebsocketHandler(c *gin.Context) {
 		return
 	}
 
-	// Check if this is a spectator connection (they want to receive video streams)
-	// Allow spectators to connect even if room has 2 debaters
+	// Check if this is a spectator connection.
+	// Spectators are allowed to connect even if the room has 2 debaters.
 	isSpectator := strings.EqualFold(c.Query("spectator"), "true")
-	room.Mutex.Lock()
-	currentDebaters := 0
-	for _, existing := range room.Clients {
-		if !existing.IsSpectator {
-			currentDebaters++
-		}
-	}
-	maxDebaters := 2
-	if !isSpectator && currentDebaters >= maxDebaters {
-		room.Mutex.Unlock()
-		log.Printf("[ws] rejecting debater %s for room %s: already full", email, roomID)
-		conn.Close()
-		return
-	}
-	room.Mutex.Unlock()
 
 	if avatarURL == "" {
 		avatarURL = "https://api.dicebear.com/9.x/big-ears/svg?seed=Nolan"
@@ -335,10 +339,12 @@ func WebsocketHandler(c *gin.Context) {
 	// Mark as spectator if needed (we can add a field to Client struct for this)
 	// For now, we'll handle it through the message handlers
 
-	// Send current participants to the new client
-	room.Mutex.Lock()
-	room.Clients[conn] = client
-	room.Mutex.Unlock()
+	// Atomically check the debater limit and register the client.
+	if !tryAddClient(room, conn, client) {
+		log.Printf("[ws] rejecting debater %s for room %s: already full", email, roomID)
+		conn.Close()
+		return
+	}
 
 	// Send participants list to newly connected client
 	participantsMsg := buildParticipantsMessage(room)

--- a/backend/websocket/websocket.go
+++ b/backend/websocket/websocket.go
@@ -351,7 +351,7 @@ func WebsocketHandler(c *gin.Context) {
 	client.SafeWriteJSON(participantsMsg)
 
 	// Send existing participants' detailed info to the new client
-	for connRef, existing := range room.Clients {
+	for _, existing := range snapshotRecipients(room, nil) {
 		payload := map[string]interface{}{
 			"id":          existing.UserID,
 			"username":    existing.Username,
@@ -360,18 +360,13 @@ func WebsocketHandler(c *gin.Context) {
 			"avatarUrl":   existing.AvatarURL,
 			"elo":         existing.Elo,
 		}
+
 		detailMessage := map[string]interface{}{
 			"type":        "userDetails",
 			"userDetails": payload,
 		}
 
-		if connRef == conn {
-			// Already sent this client's participant data; ensure they have their own detail payload too
-			client.SafeWriteJSON(detailMessage)
-		} else {
-			// Send existing participant info to the new client
-			client.SafeWriteJSON(detailMessage)
-		}
+		client.SafeWriteJSON(detailMessage)
 	}
 
 	// Prepare detailed payload for the new client to broadcast to others

--- a/backend/websocket/websocket_test.go
+++ b/backend/websocket/websocket_test.go
@@ -1,6 +1,7 @@
 package websocket
 
 import (
+	"sync"
 	"testing"
 
 	gorilla "github.com/gorilla/websocket"
@@ -35,5 +36,54 @@ func TestBuildParticipantsMessageIncludesRecoverableRoomState(t *testing.T) {
 	}
 	if role, ok := participant["role"].(string); !ok || role != "for" {
 		t.Fatalf("expected role=for, got %#v", participant["role"])
+	}
+}
+
+func TestTryAddClientDoesNotExceedDebaterLimit(t *testing.T) {
+	room := &Room{
+		Clients: make(map[*gorilla.Conn]*Client),
+	}
+
+	// Start with one debater already in the room.
+	existingConn := &gorilla.Conn{}
+	room.Clients[existingConn] = &Client{
+		Conn:        existingConn,
+		IsSpectator: false,
+	}
+
+	const attempts = 100
+
+	var wg sync.WaitGroup
+	var accepted int
+	var acceptedMutex sync.Mutex
+
+	for i := 0; i < attempts; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			conn := &gorilla.Conn{}
+			client := &Client{
+				Conn:        conn,
+				IsSpectator: false,
+			}
+
+			if tryAddClient(room, conn, client) {
+				acceptedMutex.Lock()
+				accepted++
+				acceptedMutex.Unlock()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if accepted != 1 {
+		t.Fatalf("expected exactly one additional debater to be accepted, got %d", accepted)
+	}
+
+	if countDebaters(room) != 2 {
+		t.Fatalf("expected room to contain exactly 2 debaters, got %d", countDebaters(room))
 	}
 }

--- a/backend/websocket/websocket_test.go
+++ b/backend/websocket/websocket_test.go
@@ -39,6 +39,8 @@ func TestBuildParticipantsMessageIncludesRecoverableRoomState(t *testing.T) {
 	}
 }
 
+// TestTryAddClientDoesNotExceedDebaterLimit verifies that concurrent debater
+// join attempts cannot exceed the room's two-debater limit.
 func TestTryAddClientDoesNotExceedDebaterLimit(t *testing.T) {
 	room := &Room{
 		Clients: make(map[*gorilla.Conn]*Client),


### PR DESCRIPTION
### Addressed Issues

Fixes #402

### Description

This PR fixes concurrency issues in the WebSocket room client management.

Previously, the room's debater count was checked while holding `room.Mutex`, but the client was registered in `room.Clients` in a separate critical section.

Because the check and registration were not atomic, multiple concurrent debater connections could observe the same available slot and pass the capacity check before being registered. This could allow more than two debaters to join the same room.

This change makes the debater capacity check and client registration atomic by performing both operations under the same `room.Mutex`.

Additionally, `WebsocketHandler` previously iterated directly over the shared `room.Clients` map while other goroutines could modify it during client admission or disconnection. The recipient list is now obtained using `snapshotRecipients`, ensuring the map is accessed safely before sending the detail payloads.

Spectators are not affected by the two-debater limit and can still join the room.

### Changes Made

- Added `tryAddClient` to atomically:
  - Check the current number of debaters in the room.
  - Reject a new debater when the room already contains two.
  - Register the client when capacity is available.
- Removed the separate debater capacity check from `WebsocketHandler`.
- Replaced the direct `room.Clients` registration with the atomic admission operation.
- Updated `WebsocketHandler` to use `snapshotRecipients` when iterating over room clients.
- Removed redundant conditional logic when sending user detail payloads.
- Added a concurrency regression test to verify that concurrent connection attempts cannot cause the room to exceed the two-debater limit.

### Testing

The following checks were performed:

- `go test ./websocket`
- `go test -race ./websocket`
- `git diff --check`
- `gofmt -d websocket/websocket.go`

All checks passed successfully.

### Screenshots/Recordings

Not applicable — this is a backend concurrency fix with no UI changes.

### Additional Notes

The fix avoids holding `room.Mutex` across slow operations such as WebSocket setup or other external work. The lock is only held for the critical admission and registration operation.

The existing `snapshotRecipients` helper is used to safely obtain a stable list of clients before iterating over them, preventing unsafe concurrent access to `room.Clients`.

### AI Usage Disclosure

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and understand the requirements.

I used ChatGPT as an implementation aid for code syntax and iteration. I made the design and implementation decisions, reviewed the generated code, and verified the changes with tests.

AI tool used:
- ChatGPT

### Checklist

- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions.
- [x] If applicable, I have made corresponding changes or additions to the documentation.
- [x] If applicable, I have made corresponding changes or additions to tests.
- [x] My changes generate no new warnings or errors.
- [x] I have joined the Discord server and I will share a link to this PR with the project maintainers there.
- [ ] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a maximum of two debaters per room, including during simultaneous connection attempts.
  * Continued allowing spectators to join when the debater capacity is full.
  * Improved consistency when sharing existing participant details with connected clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->